### PR TITLE
Add CLAUDE.md for Claude Code orientation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+## Commands
+
+```bash
+pnpm dev                    # all apps
+pnpm dev:server             # server only (Cloudflare Workers)
+pnpm dev:native             # native only (Expo)
+
+pnpm test                   # all tests
+pnpm test:server            # server tests (vitest)
+pnpm test:native            # native tests (jest)
+# Single test file:
+pnpm --filter server test -- workout-schema
+pnpm --filter native test -- MyComponent
+
+pnpm check                  # oxlint + oxfmt --write
+pnpm check:ci               # oxlint + oxfmt --check (no write)
+pnpm check-types            # tsc across all packages
+
+pnpm db:generate            # drizzle-kit generate
+pnpm db:push                # drizzle-kit push
+```
+
+## Architecture
+
+pnpm workspace monorepo: `apps/*`, `packages/*`.
+
+**Apps:**
+- `apps/server` — Hono on Cloudflare Workers. tRPC at `/trpc/*`, auth at `/api/auth/*`.
+- `apps/native` — Expo Router + HeroUI Native + TanStack Query.
+
+**Packages** (`@ironlog/*`):
+- `api` — tRPC router & context
+- `auth` — Better Auth config
+- `db` — Drizzle ORM + libSQL (Turso). Schema at `packages/db/src/schema/`.
+- `env` — type-safe env (`@t3-oss/env-core` for native, Cloudflare bindings for server)
+- `config` — shared tsconfig
+- `infra` — Alchemy (Cloudflare infra-as-code)
+
+**Data flow:** Native → tRPC client → Hono server → tRPC router → Drizzle → libSQL/Turso
+
+## Testing
+
+- **Server:** Vitest with `@cloudflare/vitest-pool-workers` (tests run in Miniflare). Config: `apps/server/vitest.config.ts`.
+- **Native:** Jest with `jest-expo` preset. Config: `apps/native/jest.config.js`.
+- Test files live next to source (colocated).
+
+## Workflow
+
+- Always use `pnpm` (never npm/yarn/bun for package management).
+- Always create a branch before starting work.
+- Always use `/tdd` skill for feature and bug work.
+- Linting is oxlint + oxfmt (not eslint/prettier).


### PR DESCRIPTION
## Summary
- Adds a minimal `CLAUDE.md` covering commands, architecture, testing setup, and workflow rules
- Gives future Claude Code sessions quick orientation in this monorepo
- All commands verified against actual `package.json` scripts

## Test plan
- [x] Verify all listed pnpm commands match root/app package.json scripts
- [x] Confirm architecture details (packages, data flow, tech stack) are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)