### PR TITLE
Add tRPC workout CRUD endpoints

### DIFF
--- a/apps/server/src/__tests__/helpers/setup-db.ts
+++ b/apps/server/src/__tests__/helpers/setup-db.ts
@@ -1,0 +1,39 @@
+import { env } from "cloudflare:workers";
+
+export async function createWorkoutTables() {
+  await env.DB.exec(
+    "CREATE TABLE IF NOT EXISTS workouts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, created_at INTEGER DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL);",
+  );
+  await env.DB.exec(
+    'CREATE TABLE IF NOT EXISTS exercises (id INTEGER PRIMARY KEY AUTOINCREMENT, workout_id INTEGER NOT NULL REFERENCES workouts(id) ON DELETE CASCADE, name TEXT NOT NULL, "order" INTEGER NOT NULL);',
+  );
+  await env.DB.exec(
+    "CREATE INDEX IF NOT EXISTS exercises_workout_id_idx ON exercises(workout_id);",
+  );
+  await env.DB.exec(
+    'CREATE TABLE IF NOT EXISTS set_templates (id INTEGER PRIMARY KEY AUTOINCREMENT, exercise_id INTEGER NOT NULL REFERENCES exercises(id) ON DELETE CASCADE, weight REAL, target_reps INTEGER, "order" INTEGER NOT NULL);',
+  );
+  await env.DB.exec(
+    "CREATE INDEX IF NOT EXISTS set_templates_exercise_id_idx ON set_templates(exercise_id);",
+  );
+}
+
+export async function createSessionTables() {
+  await createWorkoutTables();
+  await env.DB.exec(
+    "CREATE TABLE IF NOT EXISTS sessions (id INTEGER PRIMARY KEY AUTOINCREMENT, workout_id INTEGER NOT NULL REFERENCES workouts(id), workout_title TEXT NOT NULL, started_at INTEGER NOT NULL, finished_at INTEGER NOT NULL, duration_seconds INTEGER NOT NULL);",
+  );
+  await env.DB.exec("CREATE INDEX IF NOT EXISTS sessions_workout_id_idx ON sessions(workout_id);");
+  await env.DB.exec(
+    'CREATE TABLE IF NOT EXISTS logged_exercises (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE, exercise_id INTEGER NOT NULL, name TEXT NOT NULL, "order" INTEGER NOT NULL);',
+  );
+  await env.DB.exec(
+    "CREATE INDEX IF NOT EXISTS logged_exercises_session_id_idx ON logged_exercises(session_id);",
+  );
+  await env.DB.exec(
+    'CREATE TABLE IF NOT EXISTS logged_sets (id INTEGER PRIMARY KEY AUTOINCREMENT, logged_exercise_id INTEGER NOT NULL REFERENCES logged_exercises(id) ON DELETE CASCADE, weight REAL, target_reps INTEGER, actual_reps INTEGER, done INTEGER NOT NULL DEFAULT 0, "order" INTEGER NOT NULL);',
+  );
+  await env.DB.exec(
+    "CREATE INDEX IF NOT EXISTS logged_sets_logged_exercise_id_idx ON logged_sets(logged_exercise_id);",
+  );
+}

--- a/apps/server/src/__tests__/workout-schema.test.ts
+++ b/apps/server/src/__tests__/workout-schema.test.ts
@@ -1,21 +1,11 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { env } from "cloudflare:workers";
 import { eq } from "drizzle-orm";
 import { db } from "@ironlog/db";
 import { workouts, exercises, setTemplates } from "@ironlog/db/schema";
+import { createWorkoutTables } from "./helpers/setup-db";
 
 beforeAll(async () => {
-  await env.DB.exec(
-    "CREATE TABLE workouts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, created_at INTEGER DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL);",
-  );
-  await env.DB.exec(
-    'CREATE TABLE exercises (id INTEGER PRIMARY KEY AUTOINCREMENT, workout_id INTEGER NOT NULL REFERENCES workouts(id) ON DELETE CASCADE, name TEXT NOT NULL, "order" INTEGER NOT NULL);',
-  );
-  await env.DB.exec("CREATE INDEX exercises_workout_id_idx ON exercises(workout_id);");
-  await env.DB.exec(
-    'CREATE TABLE set_templates (id INTEGER PRIMARY KEY AUTOINCREMENT, exercise_id INTEGER NOT NULL REFERENCES exercises(id) ON DELETE CASCADE, weight REAL, target_reps INTEGER, "order" INTEGER NOT NULL);',
-  );
-  await env.DB.exec("CREATE INDEX set_templates_exercise_id_idx ON set_templates(exercise_id);");
+  await createWorkoutTables();
 });
 
 describe("workout schema", () => {

--- a/apps/server/src/__tests__/workout-trpc.test.ts
+++ b/apps/server/src/__tests__/workout-trpc.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import app from "../index";
+import { createWorkoutTables } from "./helpers/setup-db";
+
+beforeAll(async () => {
+  await createWorkoutTables();
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function trpcQuery(path: string, input?: unknown): Promise<{ status: number; json: any }> {
+  const url = input
+    ? `/trpc/${path}?input=${encodeURIComponent(JSON.stringify(input))}`
+    : `/trpc/${path}`;
+  const res = await app.request(url);
+  return { status: res.status, json: await res.json() };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function trpcMutation(path: string, input: unknown): Promise<{ status: number; json: any }> {
+  const res = await app.request("/trpc/" + path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return { status: res.status, json: await res.json() };
+}
+
+describe("workout tRPC", () => {
+  // --- list ---
+  it("list returns empty array initially", async () => {
+    const { status, json } = await trpcQuery("workout.list");
+    expect(status).toBe(200);
+    expect(json.result.data).toEqual([]);
+  });
+
+  // --- create ---
+  it("create with exercises and sets", async () => {
+    const { status, json } = await trpcMutation("workout.create", {
+      title: "Push Day",
+      exercises: [
+        {
+          name: "Bench Press",
+          sets: [
+            { weight: 135, targetReps: 8 },
+            { weight: 155, targetReps: 6 },
+          ],
+        },
+        {
+          name: "Overhead Press",
+          sets: [{ weight: 95, targetReps: 10 }],
+        },
+      ],
+    });
+    expect(status).toBe(200);
+    const workout = json.result.data;
+    expect(workout.title).toBe("Push Day");
+    expect(workout.exercises).toHaveLength(2);
+    expect(workout.exercises[0].name).toBe("Bench Press");
+    expect(workout.exercises[0].setTemplates).toHaveLength(2);
+    expect(workout.exercises[0].setTemplates[0].weight).toBe(135);
+    expect(workout.exercises[0].setTemplates[0].targetReps).toBe(8);
+    expect(workout.exercises[1].name).toBe("Overhead Press");
+    expect(workout.exercises[1].setTemplates).toHaveLength(1);
+  });
+
+  it("create with zero exercises succeeds", async () => {
+    const { status, json } = await trpcMutation("workout.create", {
+      title: "Empty Workout",
+      exercises: [],
+    });
+    expect(status).toBe(200);
+    const workout = json.result.data;
+    expect(workout.title).toBe("Empty Workout");
+    expect(workout.exercises).toHaveLength(0);
+  });
+
+  it("create with null weight and targetReps", async () => {
+    const { status, json } = await trpcMutation("workout.create", {
+      title: "Bodyweight",
+      exercises: [
+        {
+          name: "Pull-ups",
+          sets: [{ weight: null, targetReps: null }],
+        },
+      ],
+    });
+    expect(status).toBe(200);
+    const set = json.result.data.exercises[0].setTemplates[0];
+    expect(set.weight).toBeNull();
+    expect(set.targetReps).toBeNull();
+  });
+
+  it("create with blank title returns 400", async () => {
+    const { status } = await trpcMutation("workout.create", {
+      title: "   ",
+      exercises: [],
+    });
+    expect(status).toBe(400);
+  });
+
+  // --- list with data ---
+  it("list returns workouts ordered by createdAt desc", async () => {
+    // Create workouts within the test to ensure data exists
+    await trpcMutation("workout.create", { title: "First", exercises: [] });
+    await trpcMutation("workout.create", { title: "Second", exercises: [] });
+    await trpcMutation("workout.create", { title: "Third", exercises: [] });
+
+    const { json } = await trpcQuery("workout.list");
+    const data = json.result.data as { id: number; title: string }[];
+    expect(data.length).toBeGreaterThanOrEqual(3);
+    // IDs should be in descending order (most recent first)
+    for (let i = 1; i < data.length; i++) {
+      expect(data[i - 1]!.id).toBeGreaterThan(data[i]!.id);
+    }
+  });
+
+  // --- getById ---
+  it("getById returns nested workout", async () => {
+    // Create a workout to get
+    const { json: createJson } = await trpcMutation("workout.create", {
+      title: "Get Test",
+      exercises: [{ name: "Squat", sets: [{ weight: 225, targetReps: 5 }] }],
+    });
+    const id = createJson.result.data.id;
+
+    const { status, json } = await trpcQuery("workout.getById", { id });
+    expect(status).toBe(200);
+    expect(json.result.data.title).toBe("Get Test");
+    expect(json.result.data.exercises[0].name).toBe("Squat");
+    expect(json.result.data.exercises[0].setTemplates[0].weight).toBe(225);
+  });
+
+  it("getById with non-existent id returns 404", async () => {
+    const { status } = await trpcQuery("workout.getById", { id: 99999 });
+    expect(status).toBe(404);
+  });
+
+  // --- delete ---
+  it("delete removes workout", async () => {
+    const { json: createJson } = await trpcMutation("workout.create", {
+      title: "To Delete",
+      exercises: [{ name: "Deadlift", sets: [{ weight: 315, targetReps: 3 }] }],
+    });
+    const id = createJson.result.data.id;
+
+    const { status } = await trpcMutation("workout.delete", { id });
+    expect(status).toBe(200);
+
+    // Verify it's gone
+    const { status: getStatus } = await trpcQuery("workout.getById", { id });
+    expect(getStatus).toBe(404);
+  });
+
+  it("delete non-existent id returns 404", async () => {
+    const { status } = await trpcMutation("workout.delete", { id: 99999 });
+    expect(status).toBe(404);
+  });
+
+  // --- update ---
+  it("update replaces title and exercises/sets", async () => {
+    const { json: createJson } = await trpcMutation("workout.create", {
+      title: "Original",
+      exercises: [{ name: "Bench", sets: [{ weight: 135, targetReps: 8 }] }],
+    });
+    const id = createJson.result.data.id;
+
+    const { status, json } = await trpcMutation("workout.update", {
+      id,
+      title: "Updated",
+      exercises: [
+        { name: "Squat", sets: [{ weight: 225, targetReps: 5 }] },
+        { name: "Lunge", sets: [] },
+      ],
+    });
+    expect(status).toBe(200);
+    const workout = json.result.data;
+    expect(workout.title).toBe("Updated");
+    expect(workout.exercises).toHaveLength(2);
+    expect(workout.exercises[0].name).toBe("Squat");
+    expect(workout.exercises[1].name).toBe("Lunge");
+    expect(workout.exercises[1].setTemplates).toHaveLength(0);
+  });
+
+  it("update non-existent id returns 404", async () => {
+    const { status } = await trpcMutation("workout.update", {
+      id: 99999,
+      title: "Nope",
+      exercises: [],
+    });
+    expect(status).toBe(404);
+  });
+
+  it("update to zero exercises", async () => {
+    const { json: createJson } = await trpcMutation("workout.create", {
+      title: "Has Exercises",
+      exercises: [{ name: "Curl", sets: [{ weight: 30, targetReps: 12 }] }],
+    });
+    const id = createJson.result.data.id;
+
+    const { status, json } = await trpcMutation("workout.update", {
+      id,
+      title: "No Exercises",
+      exercises: [],
+    });
+    expect(status).toBe(200);
+    expect(json.result.data.exercises).toHaveLength(0);
+  });
+
+  it("list returns exercises and sets ordered by order field", async () => {
+    // Create a workout with multiple exercises/sets to verify ordering
+    const { json: createJson } = await trpcMutation("workout.create", {
+      title: "Ordered",
+      exercises: [
+        {
+          name: "First",
+          sets: [
+            { weight: 100, targetReps: 10 },
+            { weight: 110, targetReps: 8 },
+          ],
+        },
+        { name: "Second", sets: [{ weight: 50, targetReps: 15 }] },
+      ],
+    });
+    const id = createJson.result.data.id;
+
+    const { json } = await trpcQuery("workout.getById", { id });
+    const workout = json.result.data;
+    expect(workout.exercises[0].name).toBe("First");
+    expect(workout.exercises[1].name).toBe("Second");
+    expect(workout.exercises[0].setTemplates[0].weight).toBe(100);
+    expect(workout.exercises[0].setTemplates[1].weight).toBe(110);
+  });
+});

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,4 +1,5 @@
 import { publicProcedure, router } from "../index";
+import { workoutRouter } from "./workout";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -9,5 +10,6 @@ export const appRouter = router({
       message: "This is private",
     };
   }),
+  workout: workoutRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/workout.ts
+++ b/packages/api/src/routers/workout.ts
@@ -1,0 +1,119 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { db, desc, eq } from "@ironlog/db";
+import { exercises, setTemplates, workouts } from "@ironlog/db/schema";
+
+import { publicProcedure, router } from "../index";
+
+const exerciseInput = z.object({
+  name: z.string().min(1),
+  sets: z.array(
+    z.object({
+      weight: z.number().nullable().optional(),
+      targetReps: z.number().int().nullable().optional(),
+    }),
+  ),
+});
+
+const createUpdateInput = z.object({
+  title: z.string().trim().min(1),
+  exercises: z.array(exerciseInput),
+});
+
+async function fetchWorkoutWithChildren(id: number) {
+  return db.query.workouts.findFirst({
+    where: eq(workouts.id, id),
+    with: {
+      exercises: {
+        orderBy: exercises.order,
+        with: {
+          setTemplates: {
+            orderBy: setTemplates.order,
+          },
+        },
+      },
+    },
+  });
+}
+
+async function insertExercisesAndSets(
+  workoutId: number,
+  exerciseInputs: z.infer<typeof createUpdateInput>["exercises"],
+) {
+  for (let i = 0; i < exerciseInputs.length; i++) {
+    const ex = exerciseInputs[i]!;
+    const [inserted] = await db
+      .insert(exercises)
+      .values({ workoutId, name: ex.name, order: i })
+      .returning();
+    for (let j = 0; j < ex.sets.length; j++) {
+      const s = ex.sets[j]!;
+      await db.insert(setTemplates).values({
+        exerciseId: inserted!.id,
+        weight: s.weight ?? null,
+        targetReps: s.targetReps ?? null,
+        order: j,
+      });
+    }
+  }
+}
+
+export const workoutRouter = router({
+  list: publicProcedure.query(async () => {
+    return db.query.workouts.findMany({
+      orderBy: [desc(workouts.createdAt), desc(workouts.id)],
+      with: {
+        exercises: {
+          orderBy: exercises.order,
+          with: {
+            setTemplates: {
+              orderBy: setTemplates.order,
+            },
+          },
+        },
+      },
+    });
+  }),
+
+  getById: publicProcedure.input(z.object({ id: z.number() })).query(async ({ input }) => {
+    const workout = await fetchWorkoutWithChildren(input.id);
+    if (!workout) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Workout not found" });
+    }
+    return workout;
+  }),
+
+  create: publicProcedure.input(createUpdateInput).mutation(async ({ input }) => {
+    const [inserted] = await db.insert(workouts).values({ title: input.title }).returning();
+    await insertExercisesAndSets(inserted!.id, input.exercises);
+    return fetchWorkoutWithChildren(inserted!.id);
+  }),
+
+  update: publicProcedure
+    .input(createUpdateInput.extend({ id: z.number() }))
+    .mutation(async ({ input }) => {
+      const existing = await db.query.workouts.findFirst({
+        where: eq(workouts.id, input.id),
+      });
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Workout not found" });
+      }
+      await db.update(workouts).set({ title: input.title }).where(eq(workouts.id, input.id));
+      // Delete old exercises (cascade deletes sets)
+      await db.delete(exercises).where(eq(exercises.workoutId, input.id));
+      await insertExercisesAndSets(input.id, input.exercises);
+      return fetchWorkoutWithChildren(input.id);
+    }),
+
+  delete: publicProcedure.input(z.object({ id: z.number() })).mutation(async ({ input }) => {
+    const existing = await db.query.workouts.findFirst({
+      where: eq(workouts.id, input.id),
+    });
+    if (!existing) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Workout not found" });
+    }
+    await db.delete(workouts).where(eq(workouts.id, input.id));
+    return { success: true };
+  }),
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,3 +4,5 @@ import { drizzle } from "drizzle-orm/d1";
 import * as schema from "./schema";
 
 export const db = drizzle(env.DB, { schema });
+
+export { eq, desc } from "drizzle-orm";


### PR DESCRIPTION
## Summary
- Add `workoutRouter` with 5 tRPC procedures: `list`, `getById`, `create`, `update`, `delete`
- Wire workout router into `appRouter` at `workout.*` namespace
- Add 14 HTTP integration tests covering all endpoints, validation, 404s, ordering, and edge cases
- Extract shared DB table-creation helper (`setup-db.ts`) to DRY up test `beforeAll` blocks
- Re-export `eq`/`desc` from `@ironlog/db` to avoid lockfile churn from adding `drizzle-orm` to the api package

## Test plan
- [x] `pnpm --filter server test` — 28/28 tests pass (4 test files)
- [x] `pnpm check-types` — no new errors (only pre-existing `NODE_ENV` in auth)
- [x] `pnpm check` — no new warnings or errors

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)