### PR TITLE
Add in-memory WorkoutContext

### DIFF
--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -16,6 +16,7 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import { AppThemeProvider } from "@/contexts/app-theme-context";
+import { WorkoutProvider } from "@/contexts/workout-context";
 import { queryClient } from "@/utils/trpc";
 
 SplashScreen.preventAutoHideAsync();
@@ -59,9 +60,11 @@ export default function Layout() {
         <GestureHandlerRootView style={{ flex: 1 }}>
           <KeyboardProvider>
             <AppThemeProvider>
-              <HeroUINativeProvider>
-                <StackLayout />
-              </HeroUINativeProvider>
+              <WorkoutProvider>
+                <HeroUINativeProvider>
+                  <StackLayout />
+                </HeroUINativeProvider>
+              </WorkoutProvider>
             </AppThemeProvider>
           </KeyboardProvider>
         </GestureHandlerRootView>

--- a/apps/native/contexts/__tests__/workout-context.test.tsx
+++ b/apps/native/contexts/__tests__/workout-context.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, renderHook, act } from "@testing-library/react-native";
+import { Text } from "react-native";
+
+import {
+  WorkoutProvider,
+  useWorkout,
+  getWorkoutById,
+  getSessionById,
+  getAllSessions,
+  getUniqueExercises,
+  isWorkoutActive,
+} from "../workout-context";
+import type { Exercise, Session, WorkoutState } from "../workout-context";
+
+describe("WorkoutContext", () => {
+  describe("Phase 1: scaffold", () => {
+    it("renders children without crashing", () => {
+      render(
+        <WorkoutProvider>
+          <Text>child</Text>
+        </WorkoutProvider>,
+      );
+      expect(screen.getByText("child")).toBeTruthy();
+    });
+
+    it("useWorkout throws outside provider", () => {
+      expect(() => renderHook(() => useWorkout())).toThrow(
+        "useWorkout must be used within WorkoutProvider",
+      );
+    });
+  });
+
+  describe("Phase 2: ADD_WORKOUT", () => {
+    it("adds a workout with auto-incremented id and createdAt", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WorkoutProvider>{children}</WorkoutProvider>
+      );
+      const { result } = renderHook(() => useWorkout(), { wrapper });
+
+      const exercises: Exercise[] = [{ id: 1, workoutId: 0, name: "Squat", order: 0, sets: [] }];
+
+      act(() => {
+        result.current.dispatch({
+          type: "ADD_WORKOUT",
+          payload: { title: "Leg Day", exercises },
+        });
+      });
+
+      const workout = result.current.state.workouts[0];
+      expect(workout).toBeDefined();
+      expect(workout.title).toBe("Leg Day");
+      expect(workout.id).toBeGreaterThan(0);
+      expect(workout.createdAt).toBeGreaterThan(0);
+      expect(workout.exercises).toEqual(exercises);
+    });
+  });
+
+  describe("Phase 3: UPDATE_WORKOUT", () => {
+    it("updates a workout by id", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WorkoutProvider>{children}</WorkoutProvider>
+      );
+      const { result } = renderHook(() => useWorkout(), { wrapper });
+
+      act(() => {
+        result.current.dispatch({
+          type: "ADD_WORKOUT",
+          payload: { title: "Leg Day", exercises: [] },
+        });
+      });
+
+      const id = result.current.state.workouts[0].id;
+
+      act(() => {
+        result.current.dispatch({
+          type: "UPDATE_WORKOUT",
+          payload: { id, title: "Push Day", exercises: [] },
+        });
+      });
+
+      expect(result.current.state.workouts[0].title).toBe("Push Day");
+      expect(result.current.state.workouts).toHaveLength(1);
+    });
+  });
+
+  describe("Phase 4: DELETE_WORKOUT", () => {
+    it("removes a workout by id", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WorkoutProvider>{children}</WorkoutProvider>
+      );
+      const { result } = renderHook(() => useWorkout(), { wrapper });
+
+      act(() => {
+        result.current.dispatch({
+          type: "ADD_WORKOUT",
+          payload: { title: "Leg Day", exercises: [] },
+        });
+      });
+
+      const id = result.current.state.workouts[0].id;
+
+      act(() => {
+        result.current.dispatch({ type: "DELETE_WORKOUT", payload: { id } });
+      });
+
+      expect(result.current.state.workouts).toHaveLength(0);
+    });
+
+    it("does not delete an active workout", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WorkoutProvider>{children}</WorkoutProvider>
+      );
+      const { result } = renderHook(() => useWorkout(), { wrapper });
+
+      act(() => {
+        result.current.dispatch({
+          type: "ADD_WORKOUT",
+          payload: { title: "Leg Day", exercises: [] },
+        });
+      });
+
+      const id = result.current.state.workouts[0].id;
+
+      act(() => {
+        result.current.dispatch({ type: "SET_ACTIVE_WORKOUT", payload: { id } });
+      });
+
+      act(() => {
+        result.current.dispatch({ type: "DELETE_WORKOUT", payload: { id } });
+      });
+
+      expect(result.current.state.workouts).toHaveLength(1);
+    });
+  });
+
+  describe("Phase 5: ADD_SESSION", () => {
+    it("adds a session to state", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WorkoutProvider>{children}</WorkoutProvider>
+      );
+      const { result } = renderHook(() => useWorkout(), { wrapper });
+
+      const session: Session = {
+        id: Date.now(),
+        workoutId: 1,
+        workoutTitle: "Leg Day",
+        startedAt: Date.now() - 3600_000,
+        finishedAt: Date.now(),
+        durationSeconds: 3600,
+        exercises: [],
+      };
+
+      act(() => {
+        result.current.dispatch({ type: "ADD_SESSION", payload: session });
+      });
+
+      expect(result.current.state.sessions).toHaveLength(1);
+      expect(result.current.state.sessions[0].workoutTitle).toBe("Leg Day");
+    });
+  });
+
+  describe("Phase 6: SET/CLEAR_ACTIVE_WORKOUT", () => {
+    it("sets and clears activeWorkoutId", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WorkoutProvider>{children}</WorkoutProvider>
+      );
+      const { result } = renderHook(() => useWorkout(), { wrapper });
+
+      expect(result.current.state.activeWorkoutId).toBeNull();
+
+      act(() => {
+        result.current.dispatch({ type: "SET_ACTIVE_WORKOUT", payload: { id: 42 } });
+      });
+
+      expect(result.current.state.activeWorkoutId).toBe(42);
+
+      act(() => {
+        result.current.dispatch({ type: "CLEAR_ACTIVE_WORKOUT" });
+      });
+
+      expect(result.current.state.activeWorkoutId).toBeNull();
+    });
+  });
+
+  describe("Phase 7: Selectors", () => {
+    const baseState: WorkoutState = {
+      workouts: [
+        {
+          id: 1,
+          title: "Leg Day",
+          createdAt: 1000,
+          exercises: [
+            { id: 10, workoutId: 1, name: "Squat", order: 0, sets: [] },
+            { id: 11, workoutId: 1, name: "Lunge", order: 1, sets: [] },
+          ],
+        },
+        {
+          id: 2,
+          title: "Push Day",
+          createdAt: 2000,
+          exercises: [
+            { id: 20, workoutId: 2, name: "Bench Press", order: 0, sets: [] },
+            { id: 21, workoutId: 2, name: "Squat", order: 1, sets: [] },
+          ],
+        },
+      ],
+      sessions: [
+        {
+          id: 100,
+          workoutId: 1,
+          workoutTitle: "Leg Day",
+          startedAt: 5000,
+          finishedAt: 6000,
+          durationSeconds: 1000,
+          exercises: [],
+        },
+        {
+          id: 101,
+          workoutId: 2,
+          workoutTitle: "Push Day",
+          startedAt: 8000,
+          finishedAt: 9000,
+          durationSeconds: 1000,
+          exercises: [],
+        },
+        {
+          id: 102,
+          workoutId: 1,
+          workoutTitle: "Leg Day",
+          startedAt: 3000,
+          finishedAt: 4000,
+          durationSeconds: 1000,
+          exercises: [],
+        },
+      ],
+      activeWorkoutId: 1,
+    };
+
+    it("getWorkoutById returns correct workout or undefined", () => {
+      expect(getWorkoutById(baseState, 1)?.title).toBe("Leg Day");
+      expect(getWorkoutById(baseState, 999)).toBeUndefined();
+    });
+
+    it("getSessionById returns correct session or undefined", () => {
+      expect(getSessionById(baseState, 100)?.workoutTitle).toBe("Leg Day");
+      expect(getSessionById(baseState, 999)).toBeUndefined();
+    });
+
+    it("getAllSessions returns sessions sorted newest-first", () => {
+      const sorted = getAllSessions(baseState);
+      expect(sorted.map((s) => s.id)).toEqual([101, 100, 102]);
+    });
+
+    it("getUniqueExercises returns deduplicated exercise names", () => {
+      const names = getUniqueExercises(baseState);
+      expect(names).toEqual(["Bench Press", "Lunge", "Squat"]);
+    });
+
+    it("isWorkoutActive checks activeWorkoutId", () => {
+      expect(isWorkoutActive(baseState, 1)).toBe(true);
+      expect(isWorkoutActive(baseState, 2)).toBe(false);
+    });
+  });
+});

--- a/apps/native/contexts/workout-context.tsx
+++ b/apps/native/contexts/workout-context.tsx
@@ -1,0 +1,194 @@
+import React, { createContext, useContext, useReducer } from "react";
+
+// --- Types ---
+
+export type SetTemplate = {
+  id: number;
+  exerciseId: number;
+  weight: number | null;
+  targetReps: number | null;
+  order: number;
+};
+
+export type Exercise = {
+  id: number;
+  workoutId: number;
+  name: string;
+  order: number;
+  sets: SetTemplate[];
+};
+
+export type Workout = {
+  id: number;
+  title: string;
+  createdAt: number;
+  exercises: Exercise[];
+};
+
+export type LoggedSet = {
+  id: number;
+  loggedExerciseId: number;
+  weight: number | null;
+  targetReps: number | null;
+  actualReps: number | null;
+  done: boolean;
+  order: number;
+};
+
+export type LoggedExercise = {
+  id: number;
+  sessionId: number;
+  exerciseId: number;
+  name: string;
+  order: number;
+  sets: LoggedSet[];
+};
+
+export type Session = {
+  id: number;
+  workoutId: number;
+  workoutTitle: string;
+  startedAt: number;
+  finishedAt: number;
+  durationSeconds: number;
+  exercises: LoggedExercise[];
+};
+
+export type WorkoutState = {
+  workouts: Workout[];
+  sessions: Session[];
+  activeWorkoutId: number | null;
+};
+
+// --- Actions ---
+
+type AddWorkoutAction = {
+  type: "ADD_WORKOUT";
+  payload: { title: string; exercises: Exercise[] };
+};
+
+type UpdateWorkoutAction = {
+  type: "UPDATE_WORKOUT";
+  payload: { id: number; title: string; exercises: Exercise[] };
+};
+
+type DeleteWorkoutAction = {
+  type: "DELETE_WORKOUT";
+  payload: { id: number };
+};
+
+type SetActiveWorkoutAction = {
+  type: "SET_ACTIVE_WORKOUT";
+  payload: { id: number };
+};
+
+type ClearActiveWorkoutAction = {
+  type: "CLEAR_ACTIVE_WORKOUT";
+};
+
+type AddSessionAction = {
+  type: "ADD_SESSION";
+  payload: Session;
+};
+
+export type WorkoutAction =
+  | AddWorkoutAction
+  | UpdateWorkoutAction
+  | DeleteWorkoutAction
+  | SetActiveWorkoutAction
+  | ClearActiveWorkoutAction
+  | AddSessionAction;
+
+// --- Reducer ---
+
+const initialState: WorkoutState = {
+  workouts: [],
+  sessions: [],
+  activeWorkoutId: null,
+};
+
+function workoutReducer(state: WorkoutState, action: WorkoutAction): WorkoutState {
+  switch (action.type) {
+    case "ADD_WORKOUT": {
+      const id = Date.now();
+      const workout: Workout = {
+        id,
+        title: action.payload.title,
+        createdAt: id,
+        exercises: action.payload.exercises,
+      };
+      return { ...state, workouts: [...state.workouts, workout] };
+    }
+    case "UPDATE_WORKOUT": {
+      const { id, ...updates } = action.payload;
+      return {
+        ...state,
+        workouts: state.workouts.map((w) => (w.id === id ? { ...w, ...updates } : w)),
+      };
+    }
+    case "DELETE_WORKOUT": {
+      if (state.activeWorkoutId === action.payload.id) return state;
+      return {
+        ...state,
+        workouts: state.workouts.filter((w) => w.id !== action.payload.id),
+      };
+    }
+    case "SET_ACTIVE_WORKOUT":
+      return { ...state, activeWorkoutId: action.payload.id };
+    case "CLEAR_ACTIVE_WORKOUT":
+      return { ...state, activeWorkoutId: null };
+    case "ADD_SESSION":
+      return { ...state, sessions: [...state.sessions, action.payload] };
+  }
+}
+
+// --- Selectors ---
+
+export function getWorkoutById(state: WorkoutState, id: number) {
+  return state.workouts.find((w) => w.id === id);
+}
+
+export function getSessionById(state: WorkoutState, id: number) {
+  return state.sessions.find((s) => s.id === id);
+}
+
+export function getAllSessions(state: WorkoutState) {
+  return [...state.sessions].sort((a, b) => b.startedAt - a.startedAt);
+}
+
+export function getUniqueExercises(state: WorkoutState) {
+  const names = new Set<string>();
+  for (const w of state.workouts) {
+    for (const e of w.exercises) {
+      names.add(e.name);
+    }
+  }
+  return [...names].sort();
+}
+
+export function isWorkoutActive(state: WorkoutState, id: number) {
+  return state.activeWorkoutId === id;
+}
+
+// --- Context ---
+
+type WorkoutContextType = {
+  state: WorkoutState;
+  dispatch: React.Dispatch<WorkoutAction>;
+};
+
+const WorkoutContext = createContext<WorkoutContextType | undefined>(undefined);
+
+export function WorkoutProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(workoutReducer, initialState);
+
+  return <WorkoutContext.Provider value={{ state, dispatch }}>{children}</WorkoutContext.Provider>;
+}
+
+export function useWorkout() {
+  const context = useContext(WorkoutContext);
+  if (!context) {
+    throw new Error("useWorkout must be used within WorkoutProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- Add React Context + `useReducer` for local workout/session state (no persistence for v1)
- 6 reducer actions: `ADD_WORKOUT`, `UPDATE_WORKOUT`, `DELETE_WORKOUT`, `SET_ACTIVE_WORKOUT`, `CLEAR_ACTIVE_WORKOUT`, `ADD_SESSION`
- 5 selector functions: `getWorkoutById`, `getSessionById`, `getAllSessions` (sorted), `getUniqueExercises`, `isWorkoutActive`
- Wire `WorkoutProvider` into root layout

Closes #8

## Test plan
- [x] 13 unit tests covering all actions, guards, and selectors (`pnpm test:native -- workout-context`)
- [ ] Verify app boots without crash on device/simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)