### PR TITLE
Add exercise autocomplete data & utilities

### DIFF
--- a/apps/native/utils/__tests__/exercises.test.ts
+++ b/apps/native/utils/__tests__/exercises.test.ts
@@ -1,0 +1,66 @@
+import { EXERCISES, filterExercises, highlightMatch } from "../exercises";
+
+describe("EXERCISES", () => {
+  it("has exactly 49 entries", () => {
+    expect(EXERCISES).toHaveLength(49);
+  });
+
+  it("contains only strings", () => {
+    for (const name of EXERCISES) {
+      expect(typeof name).toBe("string");
+    }
+  });
+});
+
+describe("filterExercises", () => {
+  it("returns [] for empty string", () => {
+    expect(filterExercises("")).toEqual([]);
+  });
+
+  it("returns [] for whitespace-only", () => {
+    expect(filterExercises("   ")).toEqual([]);
+    expect(filterExercises("  \t ")).toEqual([]);
+  });
+
+  it("matches substring case-insensitively for 'bench'", () => {
+    const results = filterExercises("bench");
+    expect(results).toEqual(["Bench Press", "Incline Bench Press", "Decline Bench Press"]);
+  });
+
+  it("matches substring case-insensitively for 'CuRl'", () => {
+    const results = filterExercises("CuRl");
+    expect(results).toEqual([
+      "Leg Curl",
+      "Bicep Curl",
+      "Hammer Curl",
+      "Preacher Curl",
+      "Incline Dumbbell Curl",
+    ]);
+  });
+});
+
+describe("highlightMatch", () => {
+  it("highlights match at the start", () => {
+    expect(highlightMatch("Bench Press", "bench")).toEqual({
+      before: "",
+      match: "Bench",
+      after: " Press",
+    });
+  });
+
+  it("highlights match in the middle", () => {
+    expect(highlightMatch("Incline Bench Press", "bench")).toEqual({
+      before: "Incline ",
+      match: "Bench",
+      after: " Press",
+    });
+  });
+
+  it("returns full name as before when no match", () => {
+    expect(highlightMatch("Deadlift", "xyz")).toEqual({
+      before: "Deadlift",
+      match: "",
+      after: "",
+    });
+  });
+});

--- a/apps/native/utils/exercises.ts
+++ b/apps/native/utils/exercises.ts
@@ -1,0 +1,71 @@
+export const EXERCISES: string[] = [
+  "Bench Press",
+  "Incline Bench Press",
+  "Decline Bench Press",
+  "Chest Fly",
+  "Cable Crossover",
+  "Push Up",
+  "Dips",
+  "Squat",
+  "Front Squat",
+  "Leg Press",
+  "Leg Extension",
+  "Leg Curl",
+  "Romanian Deadlift",
+  "Deadlift",
+  "Sumo Deadlift",
+  "Hip Thrust",
+  "Calf Raise",
+  "Pull Up",
+  "Chin Up",
+  "Lat Pulldown",
+  "Seated Row",
+  "Bent Over Row",
+  "T-Bar Row",
+  "Shoulder Press",
+  "Arnold Press",
+  "Lateral Raise",
+  "Front Raise",
+  "Face Pull",
+  "Shrug",
+  "Bicep Curl",
+  "Hammer Curl",
+  "Preacher Curl",
+  "Tricep Pushdown",
+  "Skull Crusher",
+  "Overhead Tricep Extension",
+  "Plank",
+  "Crunch",
+  "Leg Raise",
+  "Russian Twist",
+  "Cable Row",
+  "Chest Supported Row",
+  "Incline Dumbbell Curl",
+  "Goblet Squat",
+  "Bulgarian Split Squat",
+  "Lunges",
+  "Step Up",
+  "Box Jump",
+  "Battle Ropes",
+  "Farmer Carry",
+];
+
+export function filterExercises(query: string): string[] {
+  const trimmed = query.trim();
+  if (trimmed === "") return [];
+  const lower = trimmed.toLowerCase();
+  return EXERCISES.filter((name) => name.toLowerCase().includes(lower));
+}
+
+export function highlightMatch(
+  name: string,
+  query: string,
+): { before: string; match: string; after: string } {
+  const index = name.toLowerCase().indexOf(query.toLowerCase());
+  if (index === -1) return { before: name, match: "", after: "" };
+  return {
+    before: name.slice(0, index),
+    match: name.slice(index, index + query.length),
+    after: name.slice(index + query.length),
+  };
+}


### PR DESCRIPTION
## Summary
- Add static `EXERCISES` array (49 entries) for autocomplete dropdown
- Add `filterExercises(query)` — case-insensitive substring filter, returns `[]` for blank input
- Add `highlightMatch(name, query)` — splits name into `{ before, match, after }` for highlight rendering

Closes #9

## Test plan
- [x] 9 Jest tests covering all exports (array shape, filter edge cases, highlight segments)
- [x] `pnpm --filter native test -- exercises` passes
- [x] `pnpm check` clean (no new warnings)
- [x] Type-checks with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)