### PR TITLE
Add workouts list screen & workout form sheet

### DIFF
--- a/apps/native/app/(tabs)/workouts.tsx
+++ b/apps/native/app/(tabs)/workouts.tsx
@@ -1,16 +1,159 @@
-import { Text, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Container } from "@/components/container";
-import { Colors } from "@/theme";
+import { WorkoutCard } from "@/components/workout-card";
+import { WorkoutFormSheet } from "@/components/workout-form-sheet";
+import type { Workout } from "@/contexts/workout-context";
+import { useWorkout } from "@/contexts/workout-context";
+import { Colors, TAP_MIN } from "@/theme";
 
 export default function WorkoutsScreen() {
+  const { state, dispatch } = useWorkout();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const [sheetVisible, setSheetVisible] = useState(false);
+  const [editingWorkout, setEditingWorkout] = useState<Workout | null>(null);
+
+  function handleNew() {
+    setEditingWorkout(null);
+    setSheetVisible(true);
+  }
+
+  function handleEdit(workout: Workout) {
+    setEditingWorkout(workout);
+    setSheetVisible(true);
+  }
+
+  function handleDelete(id: number) {
+    dispatch({ type: "DELETE_WORKOUT", payload: { id } });
+  }
+
+  function handleStart(id: number) {
+    router.push(`/log/${id}`);
+  }
+
+  function handleCloseSheet() {
+    setSheetVisible(false);
+    setEditingWorkout(null);
+  }
+
   return (
     <Container isScrollable={false}>
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <Text style={{ color: Colors.text1, fontFamily: "DMSans_600SemiBold", fontSize: 20 }}>
-          Workouts
-        </Text>
-      </View>
+      <FlatList
+        data={state.workouts}
+        keyExtractor={(item) => String(item.id)}
+        contentContainerStyle={[styles.listContent, { paddingTop: insets.top + 8 }]}
+        ListHeaderComponent={
+          <View>
+            {/* App header */}
+            <View style={styles.appHeader}>
+              <Text style={styles.appTitle}>IronLog</Text>
+              <Text style={styles.bolt}>⚡</Text>
+            </View>
+            <Text style={styles.subtitle}>Build your workout templates</Text>
+
+            {/* Section header */}
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>MY WORKOUTS</Text>
+              <Pressable onPress={handleNew} style={styles.newBtn} hitSlop={4}>
+                <Text style={styles.newBtnText}>+ New</Text>
+              </Pressable>
+            </View>
+          </View>
+        }
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text style={styles.emptyTitle}>No workouts yet</Text>
+            <Text style={styles.emptyText}>Tap "+ New" to create your first workout template</Text>
+          </View>
+        }
+        renderItem={({ item }) => (
+          <WorkoutCard
+            workout={item}
+            state={state}
+            onEdit={() => handleEdit(item)}
+            onDelete={() => handleDelete(item.id)}
+            onStart={() => handleStart(item.id)}
+          />
+        )}
+      />
+
+      <WorkoutFormSheet
+        visible={sheetVisible}
+        onClose={handleCloseSheet}
+        editWorkout={editingWorkout}
+        dispatch={dispatch}
+      />
     </Container>
   );
 }
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 100,
+  },
+  appHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  appTitle: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 26,
+    color: Colors.accent,
+  },
+  bolt: {
+    fontSize: 20,
+  },
+  subtitle: {
+    fontFamily: "DMSans_400Regular",
+    fontSize: 13,
+    color: Colors.text3,
+    marginTop: 2,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: 24,
+    marginBottom: 14,
+  },
+  sectionTitle: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 12,
+    color: Colors.text3,
+    letterSpacing: 1.5,
+  },
+  newBtn: {
+    backgroundColor: Colors.accent,
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    minHeight: TAP_MIN,
+    justifyContent: "center",
+  },
+  newBtnText: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 14,
+    color: Colors.bg,
+  },
+  empty: {
+    alignItems: "center",
+    paddingTop: 60,
+  },
+  emptyTitle: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 16,
+    color: Colors.text2,
+  },
+  emptyText: {
+    fontFamily: "DMSans_400Regular",
+    fontSize: 13,
+    color: Colors.text3,
+    marginTop: 6,
+  },
+});

--- a/apps/native/components/exercise-autocomplete.tsx
+++ b/apps/native/components/exercise-autocomplete.tsx
@@ -1,0 +1,105 @@
+import { useRef, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+
+import { Colors, RADIUS_INPUT } from "@/theme";
+import { filterExercises, highlightMatch } from "@/utils/exercises";
+
+type Props = {
+  value: string;
+  onChangeText: (text: string) => void;
+  onSelect: (name: string) => void;
+};
+
+export function ExerciseAutocomplete({ value, onChangeText, onSelect }: Props) {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const results = filterExercises(value);
+
+  function handleFocus() {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setShowDropdown(true);
+  }
+
+  function handleBlur() {
+    timeoutRef.current = setTimeout(() => setShowDropdown(false), 150);
+  }
+
+  function handleSelect(name: string) {
+    onSelect(name);
+    setShowDropdown(false);
+  }
+
+  return (
+    <View style={styles.wrapper}>
+      <TextInput
+        style={styles.input}
+        value={value}
+        onChangeText={onChangeText}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        placeholder="Search exercise…"
+        placeholderTextColor={Colors.text4}
+      />
+      {showDropdown && results.length > 0 && (
+        <ScrollView style={styles.dropdown} keyboardShouldPersistTaps="handled" nestedScrollEnabled>
+          {results.map((name) => {
+            const parts = highlightMatch(name, value);
+            return (
+              <Pressable key={name} style={styles.item} onPress={() => handleSelect(name)}>
+                <Text style={styles.itemText}>
+                  {parts.before}
+                  <Text style={styles.highlight}>{parts.match}</Text>
+                  {parts.after}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: "relative",
+    zIndex: 50,
+    flex: 1,
+  },
+  input: {
+    backgroundColor: Colors.surface2,
+    borderColor: Colors.border,
+    borderWidth: 1,
+    borderRadius: RADIUS_INPUT,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontFamily: "DMSans_400Regular",
+    fontSize: 14,
+    color: Colors.text1,
+  },
+  dropdown: {
+    position: "absolute",
+    top: "100%",
+    left: 0,
+    right: 0,
+    maxHeight: 200,
+    backgroundColor: Colors.surface3,
+    borderRadius: RADIUS_INPUT,
+    borderColor: Colors.border,
+    borderWidth: 1,
+    marginTop: 4,
+  },
+  item: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  itemText: {
+    fontFamily: "DMSans_400Regular",
+    fontSize: 14,
+    color: Colors.text2,
+  },
+  highlight: {
+    color: Colors.accent,
+    fontFamily: "DMSans_700Bold",
+  },
+});

--- a/apps/native/components/workout-card.tsx
+++ b/apps/native/components/workout-card.tsx
@@ -1,0 +1,128 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import type { Workout, WorkoutState } from "@/contexts/workout-context";
+import { isWorkoutActive } from "@/contexts/workout-context";
+import { Colors, RADIUS_CARD, TAP_MIN } from "@/theme";
+
+type Props = {
+  workout: Workout;
+  state: WorkoutState;
+  onEdit: () => void;
+  onDelete: () => void;
+  onStart: () => void;
+};
+
+export function WorkoutCard({ workout, state, onEdit, onDelete, onStart }: Props) {
+  const active = isWorkoutActive(state, workout.id);
+  const totalSets = workout.exercises.reduce((sum, e) => sum + e.sets.length, 0);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{workout.title}</Text>
+      <Text style={styles.meta}>
+        {workout.exercises.length} exercise{workout.exercises.length !== 1 ? "s" : ""} · {totalSets}{" "}
+        set{totalSets !== 1 ? "s" : ""}
+      </Text>
+
+      {workout.exercises.length > 0 && (
+        <View style={styles.pillRow}>
+          {workout.exercises.map((ex) => (
+            <View key={ex.id} style={styles.pill}>
+              <Text style={styles.pillText}>{ex.name}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      <View style={styles.actionRow}>
+        <Pressable onPress={onEdit} style={styles.actionBtn} hitSlop={4}>
+          <Text style={styles.actionText}>✏️ Edit</Text>
+        </Pressable>
+        <Pressable
+          onPress={onDelete}
+          style={[styles.actionBtn, active && styles.actionDisabled]}
+          disabled={active}
+          hitSlop={4}
+        >
+          <Text style={[styles.actionText, active && styles.actionTextDisabled]}>🗑 Delete</Text>
+        </Pressable>
+        <Pressable onPress={onStart} style={styles.startBtn} hitSlop={4}>
+          <Text style={styles.startText}>▶ Start</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: Colors.surface1,
+    borderColor: Colors.border,
+    borderWidth: 1,
+    borderRadius: RADIUS_CARD,
+    padding: 16,
+    marginBottom: 12,
+  },
+  title: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 22,
+    color: Colors.text1,
+  },
+  meta: {
+    fontFamily: "DMSans_400Regular",
+    fontSize: 12,
+    color: Colors.text3,
+    marginTop: 2,
+  },
+  pillRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+    marginTop: 10,
+  },
+  pill: {
+    backgroundColor: Colors.surface2,
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  pillText: {
+    fontFamily: "DMSans_400Regular",
+    fontSize: 11,
+    color: Colors.text2,
+  },
+  actionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginTop: 14,
+  },
+  actionBtn: {
+    minHeight: TAP_MIN,
+    justifyContent: "center",
+  },
+  actionDisabled: {
+    opacity: 0.35,
+  },
+  actionText: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 13,
+    color: Colors.text2,
+  },
+  actionTextDisabled: {
+    color: Colors.text4,
+  },
+  startBtn: {
+    marginLeft: "auto",
+    backgroundColor: Colors.orange,
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    minHeight: TAP_MIN,
+    justifyContent: "center",
+  },
+  startText: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 13,
+    color: Colors.text1,
+  },
+});

--- a/apps/native/components/workout-form-sheet.tsx
+++ b/apps/native/components/workout-form-sheet.tsx
@@ -1,0 +1,393 @@
+import { useEffect, useState } from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import type { Exercise, Workout, WorkoutAction } from "@/contexts/workout-context";
+import { Colors, RADIUS_CARD, RADIUS_INPUT, TAP_MIN } from "@/theme";
+
+import { ExerciseAutocomplete } from "./exercise-autocomplete";
+
+type FormSet = { localId: string; weight: string; targetReps: string };
+type FormExercise = { localId: string; name: string; sets: FormSet[] };
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  editWorkout: Workout | null;
+  dispatch: React.Dispatch<WorkoutAction>;
+};
+
+function makeSet(): FormSet {
+  return { localId: String(Date.now()) + String(Math.random()), weight: "", targetReps: "" };
+}
+
+function makeExercise(name: string): FormExercise {
+  return { localId: String(Date.now()) + String(Math.random()), name, sets: [makeSet()] };
+}
+
+export function WorkoutFormSheet({ visible, onClose, editWorkout, dispatch }: Props) {
+  const [title, setTitle] = useState("");
+  const [exercises, setExercises] = useState<FormExercise[]>([]);
+  const [searchText, setSearchText] = useState("");
+
+  useEffect(() => {
+    if (!visible) return;
+    if (editWorkout) {
+      setTitle(editWorkout.title);
+      setExercises(
+        editWorkout.exercises.map((ex) => ({
+          localId: String(ex.id),
+          name: ex.name,
+          sets: ex.sets.map((s) => ({
+            localId: String(s.id),
+            weight: s.weight != null ? String(s.weight) : "",
+            targetReps: s.targetReps != null ? String(s.targetReps) : "",
+          })),
+        })),
+      );
+    } else {
+      setTitle("");
+      setExercises([]);
+    }
+    setSearchText("");
+  }, [visible, editWorkout]);
+
+  function handleAddExercise(name: string) {
+    setExercises((prev) => [...prev, makeExercise(name)]);
+    setSearchText("");
+  }
+
+  function handleRemoveExercise(localId: string) {
+    setExercises((prev) => prev.filter((e) => e.localId !== localId));
+  }
+
+  function handleAddSet(exerciseLocalId: string) {
+    setExercises((prev) =>
+      prev.map((e) => (e.localId === exerciseLocalId ? { ...e, sets: [...e.sets, makeSet()] } : e)),
+    );
+  }
+
+  function handleRemoveSet(exerciseLocalId: string, setLocalId: string) {
+    setExercises((prev) =>
+      prev.map((e) =>
+        e.localId === exerciseLocalId
+          ? { ...e, sets: e.sets.filter((s) => s.localId !== setLocalId) }
+          : e,
+      ),
+    );
+  }
+
+  function handleSetField(
+    exerciseLocalId: string,
+    setLocalId: string,
+    field: "weight" | "targetReps",
+    value: string,
+  ) {
+    setExercises((prev) =>
+      prev.map((e) =>
+        e.localId === exerciseLocalId
+          ? {
+              ...e,
+              sets: e.sets.map((s) => (s.localId === setLocalId ? { ...s, [field]: value } : s)),
+            }
+          : e,
+      ),
+    );
+  }
+
+  function handleSave() {
+    if (!title.trim()) return;
+
+    const baseId = Date.now();
+    const builtExercises: Exercise[] = exercises.map((fe, ei) => ({
+      id: baseId + ei + 1,
+      workoutId: editWorkout?.id ?? baseId,
+      name: fe.name,
+      order: ei,
+      sets: fe.sets.map((fs, si) => ({
+        id: baseId + ei * 100 + si + 1000,
+        exerciseId: baseId + ei + 1,
+        weight: fs.weight ? Number(fs.weight) : null,
+        targetReps: fs.targetReps ? Number(fs.targetReps) : null,
+        order: si,
+      })),
+    }));
+
+    if (editWorkout) {
+      dispatch({
+        type: "UPDATE_WORKOUT",
+        payload: { id: editWorkout.id, title: title.trim(), exercises: builtExercises },
+      });
+    } else {
+      dispatch({
+        type: "ADD_WORKOUT",
+        payload: { title: title.trim(), exercises: builtExercises },
+      });
+    }
+    onClose();
+  }
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose} />
+      <View style={styles.sheet}>
+        <View style={styles.dragHandle} />
+        <ScrollView
+          style={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={styles.sheetTitle}>{editWorkout ? "Edit Workout" : "New Workout"}</Text>
+
+          {/* Workout name */}
+          <Text style={styles.label}>Workout Name</Text>
+          <TextInput
+            style={styles.nameInput}
+            value={title}
+            onChangeText={setTitle}
+            placeholder="e.g. Push Day"
+            placeholderTextColor={Colors.text4}
+          />
+
+          {/* Add exercise */}
+          <Text style={[styles.label, { marginTop: 20 }]}>Add Exercise</Text>
+          <View style={styles.addExRow}>
+            <ExerciseAutocomplete
+              value={searchText}
+              onChangeText={setSearchText}
+              onSelect={handleAddExercise}
+            />
+            <Pressable
+              style={styles.addExBtn}
+              onPress={() => {
+                if (searchText.trim()) handleAddExercise(searchText.trim());
+              }}
+            >
+              <Text style={styles.addExBtnText}>+ Add</Text>
+            </Pressable>
+          </View>
+
+          {/* Exercise blocks */}
+          {exercises.map((ex) => (
+            <View key={ex.localId} style={styles.exBlock}>
+              <View style={styles.exHeader}>
+                <Text style={styles.exName}>{ex.name}</Text>
+                <Pressable onPress={() => handleRemoveExercise(ex.localId)} hitSlop={8}>
+                  <Text style={styles.removeText}>✕</Text>
+                </Pressable>
+              </View>
+
+              {/* Set header */}
+              <View style={styles.setRow}>
+                <Text style={[styles.setLabel, { flex: 0.5 }]}>Set</Text>
+                <Text style={[styles.setLabel, { flex: 1 }]}>Weight</Text>
+                <Text style={[styles.setLabel, { flex: 1 }]}>Reps</Text>
+                <View style={{ width: 28 }} />
+              </View>
+
+              {ex.sets.map((set, si) => (
+                <View key={set.localId} style={styles.setRow}>
+                  <Text style={[styles.setNum, { flex: 0.5 }]}>{si + 1}</Text>
+                  <TextInput
+                    style={[styles.setInput, { flex: 1 }]}
+                    value={set.weight}
+                    onChangeText={(v) => handleSetField(ex.localId, set.localId, "weight", v)}
+                    keyboardType="numeric"
+                    placeholder="—"
+                    placeholderTextColor={Colors.text4}
+                  />
+                  <TextInput
+                    style={[styles.setInput, { flex: 1 }]}
+                    value={set.targetReps}
+                    onChangeText={(v) => handleSetField(ex.localId, set.localId, "targetReps", v)}
+                    keyboardType="numeric"
+                    placeholder="—"
+                    placeholderTextColor={Colors.text4}
+                  />
+                  <Pressable
+                    onPress={() => handleRemoveSet(ex.localId, set.localId)}
+                    hitSlop={8}
+                    style={{ width: 28, alignItems: "center" }}
+                  >
+                    <Text style={styles.removeText}>✕</Text>
+                  </Pressable>
+                </View>
+              ))}
+
+              <Pressable style={styles.addSetBtn} onPress={() => handleAddSet(ex.localId)}>
+                <Text style={styles.addSetText}>+ Add Set</Text>
+              </Pressable>
+            </View>
+          ))}
+
+          {/* Save button */}
+          <Pressable style={styles.saveBtn} onPress={handleSave}>
+            <Text style={styles.saveBtnText}>
+              {editWorkout ? "Update Workout" : "Save Workout"}
+            </Text>
+          </Pressable>
+
+          <View style={{ height: 40 }} />
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  sheet: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    maxHeight: "92%",
+    backgroundColor: Colors.surface1,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingTop: 12,
+  },
+  dragHandle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: Colors.border2,
+    alignSelf: "center",
+    marginBottom: 8,
+  },
+  scroll: {
+    paddingHorizontal: 20,
+  },
+  sheetTitle: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 24,
+    color: Colors.text1,
+    marginBottom: 16,
+  },
+  label: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 12,
+    color: Colors.text3,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 6,
+  },
+  nameInput: {
+    backgroundColor: Colors.surface2,
+    borderColor: Colors.border,
+    borderWidth: 1,
+    borderRadius: RADIUS_INPUT,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontFamily: "DMSans_400Regular",
+    fontSize: 15,
+    color: Colors.text1,
+  },
+  addExRow: {
+    flexDirection: "row",
+    gap: 8,
+    alignItems: "flex-start",
+    zIndex: 50,
+  },
+  addExBtn: {
+    backgroundColor: Colors.accent,
+    borderRadius: RADIUS_INPUT,
+    paddingHorizontal: 14,
+    minHeight: TAP_MIN,
+    justifyContent: "center",
+  },
+  addExBtnText: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 14,
+    color: Colors.bg,
+  },
+  exBlock: {
+    backgroundColor: Colors.surface2,
+    borderRadius: RADIUS_CARD,
+    padding: 12,
+    marginTop: 14,
+  },
+  exHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  exName: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 15,
+    color: Colors.text1,
+  },
+  removeText: {
+    color: Colors.red,
+    fontSize: 16,
+    fontFamily: "DMSans_500Medium",
+  },
+  setRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 6,
+  },
+  setLabel: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 11,
+    color: Colors.text3,
+    textTransform: "uppercase",
+  },
+  setNum: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 14,
+    color: Colors.text2,
+    textAlign: "center",
+  },
+  setInput: {
+    backgroundColor: Colors.surface3,
+    borderColor: Colors.border,
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    fontFamily: "DMSans_400Regular",
+    fontSize: 14,
+    color: Colors.text1,
+    textAlign: "center",
+  },
+  addSetBtn: {
+    borderWidth: 1,
+    borderStyle: Platform.OS === "android" ? "solid" : "dashed",
+    borderColor: Colors.border2,
+    borderRadius: 8,
+    paddingVertical: 8,
+    alignItems: "center",
+    marginTop: 4,
+  },
+  addSetText: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 13,
+    color: Colors.text3,
+  },
+  saveBtn: {
+    backgroundColor: Colors.accent,
+    borderRadius: RADIUS_CARD,
+    paddingVertical: 14,
+    alignItems: "center",
+    marginTop: 24,
+  },
+  saveBtnText: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 20,
+    color: Colors.bg,
+  },
+});


### PR DESCRIPTION
## Summary
- **WorkoutCard** component: displays title, meta (exercise/set counts), exercise pills, and edit/delete/start actions
- **ExerciseAutocomplete** component: TextInput with filtered dropdown and accent-highlighted matches
- **WorkoutFormSheet** component: Modal bottom sheet for creating/editing workouts with exercise blocks and set rows
- **Workouts screen** rewritten from stub to full FlatList with header, empty state, and form sheet integration

Closes #10, closes #11

## Test plan
- [ ] `pnpm check` passes (lint + format)
- [ ] `pnpm dev:native` — app loads on iOS sim
- [ ] Empty state visible on fresh load
- [ ] "+ New" opens form sheet → create workout → card renders
- [ ] Edit button → sheet pre-populated with workout data
- [ ] Delete removes card (disabled when workout is active)
- [ ] Start navigates to `/log/[id]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)