### PR TITLE
Add log session screen with numpad, rest timer & bottom bar

### DIFF
--- a/apps/native/app/log/[workoutId].tsx
+++ b/apps/native/app/log/[workoutId].tsx
@@ -1,29 +1,371 @@
-import { useLocalSearchParams } from "expo-router";
-import { Text, View } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { Container } from "@/components/container";
-import { Colors } from "@/theme";
+import * as Haptics from "expo-haptics";
+
+import { BottomBar } from "@/components/bottom-bar";
+import { NumpadModal } from "@/components/numpad-modal";
+import { RestTimerBanner } from "@/components/rest-timer";
+import type { NumpadMode } from "@/utils/numpad";
+import type { Workout } from "@/contexts/workout-context";
+import { getWorkoutById, useWorkout } from "@/contexts/workout-context";
+import { useElapsedTimer } from "@/hooks/use-elapsed-timer";
+import { useLogSession } from "@/hooks/use-log-session";
+import { useRestTimer } from "@/hooks/use-rest-timer";
+import { Colors, RADIUS_CARD, TAP_MIN } from "@/theme";
+
+type NumpadState = {
+  visible: boolean;
+  mode: NumpadMode;
+  exIdx: number;
+  setIdx: number;
+  initialValue: string;
+  label: string;
+};
+
+const numpadClosed: NumpadState = {
+  visible: false,
+  mode: "weight",
+  exIdx: 0,
+  setIdx: 0,
+  initialValue: "",
+  label: "",
+};
 
 export default function LogSessionScreen() {
   const { workoutId } = useLocalSearchParams<{ workoutId: string }>();
+  const insets = useSafeAreaInsets();
+  const { state, dispatch } = useWorkout();
+  const workout = getWorkoutById(state, Number(workoutId));
+
+  useEffect(() => {
+    dispatch({ type: "SET_ACTIVE_WORKOUT", payload: { id: Number(workoutId) } });
+    return () => {
+      dispatch({ type: "CLEAR_ACTIVE_WORKOUT" });
+    };
+  }, [dispatch, workoutId]);
+
+  if (!workout) {
+    return (
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <Text style={styles.notFound}>Workout not found</Text>
+      </View>
+    );
+  }
+
+  return <LogSessionInner workout={workout} />;
+}
+
+function LogSessionInner({ workout }: { workout: Workout }) {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { dispatch } = useWorkout();
+  const startedAtRef = useRef(Date.now());
+  const { elapsed, formatTime } = useElapsedTimer();
+  const log = useLogSession(workout);
+
+  const restTimer = useRestTimer(() => {
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  });
+
+  const [numpad, setNumpad] = useState<NumpadState>(numpadClosed);
+
+  // Pulsing dot animation
+  const dotOpacity = useSharedValue(1);
+  useEffect(() => {
+    dotOpacity.value = withRepeat(
+      withSequence(withTiming(0.3, { duration: 800 }), withTiming(1, { duration: 800 })),
+      -1,
+    );
+  }, [dotOpacity]);
+  const dotStyle = useAnimatedStyle(() => ({ opacity: dotOpacity.value }));
+
+  function openNumpad(mode: NumpadMode, exIdx: number, setIdx: number) {
+    const ex = log.logExercises[exIdx];
+    const set = ex.sets[setIdx];
+    const val = mode === "weight" ? set.weight : set.actualReps;
+    setNumpad({
+      visible: true,
+      mode,
+      exIdx,
+      setIdx,
+      initialValue: val != null ? String(val) : "",
+      label: `${ex.name} — Set ${setIdx + 1}`,
+    });
+  }
+
+  function handleNumpadConfirm(value: string) {
+    const num = Number(value);
+    if (numpad.mode === "weight") {
+      log.updateWeight(numpad.exIdx, numpad.setIdx, num);
+    } else {
+      log.updateReps(numpad.exIdx, numpad.setIdx, num);
+    }
+    setNumpad(numpadClosed);
+  }
+
+  function handleCheck(exIdx: number, setIdx: number) {
+    const nowDone = log.toggleDone(exIdx, setIdx);
+    if (nowDone) {
+      restTimer.start();
+    } else {
+      restTimer.cancel();
+    }
+  }
+
+  function handleLogReps() {
+    if (!log.nextUndoneSet) return;
+    const { exIdx, setIdx } = log.nextUndoneSet;
+    openNumpad("reps", exIdx, setIdx);
+  }
+
+  function handleFinish() {
+    const session = log.buildSession(startedAtRef.current);
+    dispatch({ type: "ADD_SESSION", payload: session });
+    dispatch({ type: "CLEAR_ACTIVE_WORKOUT" });
+    router.replace("/(tabs)/workouts");
+  }
 
   return (
-    <Container isScrollable={false}>
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <Text style={{ color: Colors.text1, fontFamily: "DMSans_600SemiBold", fontSize: 20 }}>
-          Log Session
-        </Text>
-        <Text
-          style={{
-            color: Colors.text3,
-            fontFamily: "DMSans_400Regular",
-            fontSize: 14,
-            marginTop: 4,
-          }}
-        >
-          Workout: {workoutId}
-        </Text>
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      {/* Header */}
+      <View style={styles.header}>
+        <View style={styles.headerLeft}>
+          <Text style={styles.workoutName}>{workout.title}</Text>
+          <View style={styles.timerRow}>
+            <Animated.View style={[styles.pulseDot, dotStyle]} />
+            <Text style={styles.timerText}>{formatTime(elapsed)}</Text>
+          </View>
+        </View>
+        <View style={styles.progressBadge} testID="progress-badge">
+          <Text style={styles.progressText}>
+            {log.progress.done}/{log.progress.total}
+          </Text>
+        </View>
       </View>
-    </Container>
+
+      {/* Set list */}
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+        {log.logExercises.map((ex, exIdx) => (
+          <View key={exIdx} style={styles.exBlock}>
+            <Text style={styles.exName}>{ex.name}</Text>
+
+            {/* Column headers */}
+            <View style={styles.setHeaderRow}>
+              <Text style={[styles.setHeaderText, { width: 32 }]}>Set</Text>
+              <Text style={[styles.setHeaderText, { flex: 1 }]}>Weight</Text>
+              <Text style={[styles.setHeaderText, { flex: 1 }]}>Reps</Text>
+              <View style={{ width: TAP_MIN }} />
+            </View>
+
+            {ex.sets.map((set, setIdx) => (
+              <View key={setIdx} style={[styles.setRow, set.done && styles.setRowDone]}>
+                <View style={styles.setBadge}>
+                  <Text style={styles.setBadgeText}>{setIdx + 1}</Text>
+                </View>
+                <Pressable
+                  style={[styles.cell, { flex: 1 }]}
+                  onPress={() => openNumpad("weight", exIdx, setIdx)}
+                  testID={`weight-cell-${exIdx}-${setIdx}`}
+                >
+                  <Text style={styles.cellText}>
+                    {set.weight != null ? String(set.weight) : "—"}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  style={[styles.cell, { flex: 1 }]}
+                  onPress={() => openNumpad("reps", exIdx, setIdx)}
+                  testID={`reps-cell-${exIdx}-${setIdx}`}
+                >
+                  <Text style={styles.cellText}>
+                    {set.actualReps != null ? String(set.actualReps) : "—"}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  style={[styles.checkBtn, set.done && styles.checkBtnDone]}
+                  onPress={() => handleCheck(exIdx, setIdx)}
+                  testID={`check-btn-${exIdx}-${setIdx}`}
+                >
+                  <Text style={[styles.checkText, set.done && styles.checkTextDone]}>✓</Text>
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        ))}
+        <View style={{ height: 120 }} />
+      </ScrollView>
+
+      <RestTimerBanner
+        isActive={restTimer.isActive}
+        remaining={restTimer.remaining}
+        onDismiss={restTimer.dismiss}
+      />
+
+      <BottomBar
+        nextSet={log.nextUndoneSet}
+        elapsed={elapsed}
+        formatTime={formatTime}
+        onLogReps={handleLogReps}
+        onFinish={handleFinish}
+      />
+
+      <NumpadModal
+        visible={numpad.visible}
+        mode={numpad.mode}
+        initialValue={numpad.initialValue}
+        label={numpad.label}
+        onConfirm={handleNumpadConfirm}
+        onClose={() => setNumpad(numpadClosed)}
+      />
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.bg,
+  },
+  notFound: {
+    color: Colors.text2,
+    fontFamily: "DMSans_500Medium",
+    fontSize: 16,
+    textAlign: "center",
+    marginTop: 40,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  headerLeft: {
+    gap: 4,
+  },
+  workoutName: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 24,
+    color: Colors.text1,
+  },
+  timerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  pulseDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.green,
+  },
+  timerText: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 14,
+    color: Colors.text2,
+  },
+  progressBadge: {
+    backgroundColor: Colors.accentDim,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  progressText: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 14,
+    color: Colors.accent,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  exBlock: {
+    marginBottom: 20,
+  },
+  exName: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 16,
+    color: Colors.text1,
+    marginBottom: 8,
+  },
+  setHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 4,
+  },
+  setHeaderText: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 11,
+    color: Colors.text3,
+    textTransform: "uppercase",
+    textAlign: "center",
+  },
+  setRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 6,
+  },
+  setRowDone: {
+    opacity: 0.4,
+  },
+  setBadge: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: Colors.surface2,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  setBadgeText: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 13,
+    color: Colors.text2,
+  },
+  cell: {
+    backgroundColor: Colors.surface2,
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: "center",
+    minHeight: TAP_MIN,
+    justifyContent: "center",
+  },
+  cellText: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 15,
+    color: Colors.text1,
+  },
+  checkBtn: {
+    width: TAP_MIN,
+    height: TAP_MIN,
+    borderRadius: RADIUS_CARD,
+    backgroundColor: Colors.surface2,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  checkBtnDone: {
+    backgroundColor: Colors.greenDim,
+  },
+  checkText: {
+    fontSize: 18,
+    color: Colors.text3,
+  },
+  checkTextDone: {
+    color: Colors.green,
+  },
+});

--- a/apps/native/app/log/__tests__/[workoutId].test.tsx
+++ b/apps/native/app/log/__tests__/[workoutId].test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import React from "react";
+
+import { WorkoutProvider, useWorkout } from "@/contexts/workout-context";
+import type { Exercise } from "@/contexts/workout-context";
+
+// Mock expo-router
+const mockRouter = { replace: jest.fn(), back: jest.fn() };
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ workoutId: "1" }),
+  useRouter: () => mockRouter,
+}));
+
+// Mock expo-haptics
+jest.mock("expo-haptics", () => ({
+  notificationAsync: jest.fn(),
+  NotificationFeedbackType: { Success: "success" },
+}));
+
+// Mock react-native-safe-area-context
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// Mock reanimated
+jest.mock("react-native-reanimated", () => {
+  const RN = require("react-native");
+  const mock = {
+    __esModule: true,
+    default: {
+      createAnimatedComponent: (c: unknown) => c,
+      View: RN.View,
+      Text: RN.Text,
+    },
+    useSharedValue: jest.fn((init: number) => ({ value: init })),
+    useAnimatedStyle: jest.fn(() => ({})),
+    withTiming: jest.fn((val: number) => val),
+    withRepeat: jest.fn((val: number) => val),
+    withSequence: jest.fn((...vals: number[]) => vals[0]),
+    createAnimatedComponent: (c: unknown) => c,
+  };
+  return mock;
+});
+
+import LogSessionScreen from "../[workoutId]";
+
+const exercises: Exercise[] = [
+  {
+    id: 10,
+    workoutId: 1,
+    name: "Bench Press",
+    order: 0,
+    sets: [
+      { id: 100, exerciseId: 10, weight: 135, targetReps: 8, order: 0 },
+      { id: 101, exerciseId: 10, weight: 135, targetReps: 8, order: 1 },
+    ],
+  },
+  {
+    id: 11,
+    workoutId: 1,
+    name: "OHP",
+    order: 1,
+    sets: [{ id: 200, exerciseId: 11, weight: 95, targetReps: 10, order: 0 }],
+  },
+];
+
+function renderScreen() {
+  // Set Date.now to return 1 so workout id matches "1"
+  jest.useFakeTimers();
+  jest.setSystemTime(1);
+
+  const AddWorkoutThenRender = () => {
+    const { dispatch, state } = useWorkout();
+    React.useEffect(() => {
+      if (state.workouts.length === 0) {
+        dispatch({ type: "ADD_WORKOUT", payload: { title: "Push Day", exercises } });
+      }
+    }, [dispatch, state.workouts.length]);
+
+    if (state.workouts.length === 0) return null;
+    return <LogSessionScreen />;
+  };
+
+  const result = render(
+    <WorkoutProvider>
+      <AddWorkoutThenRender />
+    </WorkoutProvider>,
+  );
+
+  jest.useRealTimers();
+  return result;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("LogSessionScreen", () => {
+  it("renders workout name and exercises", () => {
+    renderScreen();
+    expect(screen.getByText("Push Day")).toBeTruthy();
+    expect(screen.getAllByText("Bench Press").length).toBeGreaterThan(0);
+    expect(screen.getByText("OHP")).toBeTruthy();
+  });
+
+  it("renders set rows with weight and reps cells", () => {
+    renderScreen();
+    const weightCells = screen.getAllByTestId(/^weight-cell-/);
+    expect(weightCells.length).toBe(3);
+    expect(weightCells[0]).toHaveTextContent("135");
+  });
+
+  it("opens numpad on weight cell press", () => {
+    renderScreen();
+    const weightCells = screen.getAllByTestId(/^weight-cell-/);
+    fireEvent.press(weightCells[0]);
+    expect(screen.getByText("Confirm")).toBeTruthy();
+    expect(screen.getByTestId("numpad-display")).toBeTruthy();
+  });
+
+  it("confirm updates weight value", () => {
+    renderScreen();
+    const weightCells = screen.getAllByTestId(/^weight-cell-/);
+    fireEvent.press(weightCells[0]);
+    // Clear existing value and type new one
+    fireEvent.press(screen.getByTestId("numpad-backspace"));
+    fireEvent.press(screen.getByTestId("numpad-backspace"));
+    fireEvent.press(screen.getByTestId("numpad-backspace"));
+    fireEvent.press(screen.getByTestId("numpad-key-4"));
+    fireEvent.press(screen.getByTestId("numpad-key-0"));
+    fireEvent.press(screen.getByTestId("numpad-key-0"));
+    fireEvent.press(screen.getByText("Confirm"));
+    expect(screen.getAllByTestId(/^weight-cell-/)[0]).toHaveTextContent("400");
+  });
+
+  it("check button toggles set done", () => {
+    renderScreen();
+    const checkBtns = screen.getAllByTestId(/^check-btn-/);
+    fireEvent.press(checkBtns[0]);
+    expect(screen.getByTestId("progress-badge")).toHaveTextContent("1/3");
+  });
+
+  it("shows progress badge with 0/total initially", () => {
+    renderScreen();
+    expect(screen.getByTestId("progress-badge")).toHaveTextContent("0/3");
+  });
+
+  it("marking done shows rest timer banner", () => {
+    renderScreen();
+    expect(screen.queryByText("REST")).toBeNull();
+    const checkBtns = screen.getAllByTestId(/^check-btn-/);
+    fireEvent.press(checkBtns[0]);
+    expect(screen.getByText("REST")).toBeTruthy();
+  });
+
+  it("un-checking hides rest timer banner", () => {
+    renderScreen();
+    const checkBtns = screen.getAllByTestId(/^check-btn-/);
+    // Check then uncheck
+    fireEvent.press(checkBtns[0]);
+    expect(screen.getByText("REST")).toBeTruthy();
+    fireEvent.press(checkBtns[0]);
+    expect(screen.queryByText("REST")).toBeNull();
+  });
+
+  it("bottom bar renders with Up Next info", () => {
+    renderScreen();
+    expect(screen.getByText("UP NEXT")).toBeTruthy();
+    // First undone is Bench Press Set 1
+    expect(screen.getByText(/Set 1/)).toBeTruthy();
+  });
+
+  it("all done hides Up Next", () => {
+    renderScreen();
+    const checkBtns = screen.getAllByTestId(/^check-btn-/);
+    fireEvent.press(checkBtns[0]);
+    fireEvent.press(checkBtns[1]);
+    fireEvent.press(checkBtns[2]);
+    expect(screen.queryByText("UP NEXT")).toBeNull();
+  });
+
+  it("finish dispatches session and navigates", () => {
+    renderScreen();
+    fireEvent.press(screen.getByTestId("finish-btn"));
+    expect(mockRouter.replace).toHaveBeenCalledWith("/(tabs)/workouts");
+  });
+});

--- a/apps/native/components/__tests__/bottom-bar.test.tsx
+++ b/apps/native/components/__tests__/bottom-bar.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import type { NextUndoneSet } from "@/hooks/use-log-session";
+
+import { BottomBar } from "../bottom-bar";
+
+const nextSet: NextUndoneSet = {
+  exIdx: 0,
+  setIdx: 1,
+  exerciseName: "Bench Press",
+  setNumber: 2,
+  weight: 135,
+};
+
+const baseProps = {
+  nextSet,
+  elapsed: 125,
+  formatTime: (s: number) => {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+  },
+  onLogReps: jest.fn(),
+  onFinish: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("BottomBar", () => {
+  it("renders Up Next card when nextSet provided", () => {
+    render(<BottomBar {...baseProps} />);
+    expect(screen.getByText("UP NEXT")).toBeTruthy();
+    expect(screen.getByText("Bench Press")).toBeTruthy();
+    expect(screen.getByText(/Set 2/)).toBeTruthy();
+  });
+
+  it("hides Up Next when nextSet is null", () => {
+    render(<BottomBar {...baseProps} nextSet={null} />);
+    expect(screen.queryByText("UP NEXT")).toBeNull();
+    expect(screen.queryByText("Bench Press")).toBeNull();
+  });
+
+  it("Log Reps button calls onLogReps", () => {
+    render(<BottomBar {...baseProps} />);
+    fireEvent.press(screen.getByText("+ Log Reps"));
+    expect(baseProps.onLogReps).toHaveBeenCalledTimes(1);
+  });
+
+  it("Finish button calls onFinish", () => {
+    render(<BottomBar {...baseProps} />);
+    fireEvent.press(screen.getByTestId("finish-btn"));
+    expect(baseProps.onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it("Finish button shows elapsed time", () => {
+    render(<BottomBar {...baseProps} />);
+    expect(screen.getByTestId("finish-btn")).toHaveTextContent("Finish · 02:05");
+  });
+});

--- a/apps/native/components/__tests__/numpad-modal.test.tsx
+++ b/apps/native/components/__tests__/numpad-modal.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { NumpadModal } from "../numpad-modal";
+
+const baseProps = {
+  visible: true,
+  mode: "weight" as const,
+  initialValue: "",
+  label: "Bench Press — Set 1",
+  onConfirm: jest.fn(),
+  onClose: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("NumpadModal", () => {
+  it("renders key grid and label when visible", () => {
+    render(<NumpadModal {...baseProps} />);
+    expect(screen.getByText("Bench Press — Set 1")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("9")).toBeTruthy();
+    expect(screen.getByText("0")).toBeTruthy();
+  });
+
+  it("does not render content when not visible", () => {
+    render(<NumpadModal {...baseProps} visible={false} />);
+    expect(screen.queryByText("1")).toBeNull();
+  });
+
+  it("pressing digits updates display", () => {
+    render(<NumpadModal {...baseProps} />);
+    fireEvent.press(screen.getByText("1"));
+    fireEvent.press(screen.getByText("3"));
+    fireEvent.press(screen.getByText("5"));
+    expect(screen.getByTestId("numpad-display")).toHaveTextContent("135");
+  });
+
+  it("confirm calls onConfirm with value", () => {
+    render(<NumpadModal {...baseProps} />);
+    fireEvent.press(screen.getByText("1"));
+    fireEvent.press(screen.getByText("3"));
+    fireEvent.press(screen.getByText("5"));
+    fireEvent.press(screen.getByText("Confirm"));
+    expect(baseProps.onConfirm).toHaveBeenCalledWith("135");
+  });
+
+  it("confirm is no-op when display is empty", () => {
+    render(<NumpadModal {...baseProps} />);
+    fireEvent.press(screen.getByText("Confirm"));
+    expect(baseProps.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("close button calls onClose", () => {
+    render(<NumpadModal {...baseProps} />);
+    fireEvent.press(screen.getByTestId("numpad-close"));
+    expect(baseProps.onClose).toHaveBeenCalled();
+  });
+
+  it("hides decimal key in reps mode", () => {
+    render(<NumpadModal {...baseProps} mode="reps" />);
+    expect(screen.queryByText(".")).toBeNull();
+  });
+
+  it("shows decimal key in weight mode", () => {
+    render(<NumpadModal {...baseProps} mode="weight" />);
+    expect(screen.getByText(".")).toBeTruthy();
+  });
+
+  it("initializes display with initialValue", () => {
+    render(<NumpadModal {...baseProps} initialValue="100" />);
+    expect(screen.getByTestId("numpad-display")).toHaveTextContent("100");
+  });
+
+  it("backspace removes last digit", () => {
+    render(<NumpadModal {...baseProps} initialValue="135" />);
+    fireEvent.press(screen.getByTestId("numpad-backspace"));
+    expect(screen.getByTestId("numpad-display")).toHaveTextContent("13");
+  });
+});

--- a/apps/native/components/__tests__/rest-timer.test.tsx
+++ b/apps/native/components/__tests__/rest-timer.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { RestTimerBanner } from "../rest-timer";
+
+const baseProps = {
+  isActive: true,
+  remaining: 75,
+  totalSeconds: 90,
+  onDismiss: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("RestTimerBanner", () => {
+  it("renders when active", () => {
+    render(<RestTimerBanner {...baseProps} />);
+    expect(screen.getByText("REST")).toBeTruthy();
+    expect(screen.getByTestId("rest-timer-countdown")).toBeTruthy();
+  });
+
+  it("does not render when inactive", () => {
+    render(<RestTimerBanner {...baseProps} isActive={false} />);
+    expect(screen.queryByText("REST")).toBeNull();
+  });
+
+  it("displays remaining time", () => {
+    render(<RestTimerBanner {...baseProps} remaining={45} />);
+    expect(screen.getByTestId("rest-timer-countdown")).toHaveTextContent("0:45");
+  });
+
+  it("dismiss button calls onDismiss", () => {
+    render(<RestTimerBanner {...baseProps} />);
+    fireEvent.press(screen.getByTestId("rest-timer-dismiss"));
+    expect(baseProps.onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders progress bar", () => {
+    render(<RestTimerBanner {...baseProps} />);
+    expect(screen.getByTestId("rest-timer-progress")).toBeTruthy();
+  });
+});

--- a/apps/native/components/bottom-bar.tsx
+++ b/apps/native/components/bottom-bar.tsx
@@ -1,0 +1,104 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import type { NextUndoneSet } from "@/hooks/use-log-session";
+import { Colors, RADIUS_CARD, TAP_MIN } from "@/theme";
+
+type Props = {
+  nextSet: NextUndoneSet | null;
+  elapsed: number;
+  formatTime: (seconds: number) => string;
+  onLogReps: () => void;
+  onFinish: () => void;
+};
+
+export function BottomBar({ nextSet, elapsed, formatTime, onLogReps, onFinish }: Props) {
+  return (
+    <View style={styles.container}>
+      {nextSet && (
+        <View style={styles.upNextCard}>
+          <View style={styles.upNextHeader}>
+            <Text style={styles.upNextLabel}>UP NEXT</Text>
+          </View>
+          <Text style={styles.upNextExercise}>{nextSet.exerciseName}</Text>
+          <View style={styles.upNextRow}>
+            <Text style={styles.upNextInfo}>
+              Set {nextSet.setNumber}
+              {nextSet.weight != null ? ` · ${nextSet.weight} lbs` : ""}
+            </Text>
+            <Pressable style={styles.logRepsBtn} onPress={onLogReps}>
+              <Text style={styles.logRepsText}>+ Log Reps</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      <Pressable style={styles.finishBtn} onPress={onFinish} testID="finish-btn">
+        <Text style={styles.finishText}>Finish · {formatTime(elapsed)}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingBottom: 34,
+    paddingTop: 8,
+  },
+  upNextCard: {
+    backgroundColor: Colors.surface2,
+    borderRadius: RADIUS_CARD,
+    padding: 12,
+    marginBottom: 8,
+  },
+  upNextHeader: {
+    marginBottom: 4,
+  },
+  upNextLabel: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 10,
+    color: Colors.text3,
+    letterSpacing: 1.5,
+  },
+  upNextExercise: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 15,
+    color: Colors.text1,
+    marginBottom: 6,
+  },
+  upNextInfo: {
+    fontFamily: "DMSans_400Regular",
+    fontSize: 13,
+    color: Colors.text2,
+    flex: 1,
+  },
+  upNextRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  logRepsBtn: {
+    backgroundColor: Colors.accentDim,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    minHeight: TAP_MIN,
+    justifyContent: "center",
+  },
+  logRepsText: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 13,
+    color: Colors.accent,
+  },
+  finishBtn: {
+    backgroundColor: Colors.orange,
+    borderRadius: RADIUS_CARD,
+    paddingVertical: 14,
+    alignItems: "center",
+    minHeight: TAP_MIN,
+    justifyContent: "center",
+  },
+  finishText: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 20,
+    color: "#fff",
+  },
+});

--- a/apps/native/components/numpad-modal.tsx
+++ b/apps/native/components/numpad-modal.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from "react";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+
+import { Colors, RADIUS_CARD, TAP_MIN } from "@/theme";
+import {
+  type NumpadKey,
+  type NumpadMode,
+  formatNumpadDisplay,
+  processNumpadInput,
+} from "@/utils/numpad";
+
+type Props = {
+  visible: boolean;
+  mode: NumpadMode;
+  initialValue: string;
+  label: string;
+  onConfirm: (value: string) => void;
+  onClose: () => void;
+};
+
+const DIGIT_KEYS: NumpadKey[][] = [
+  ["1", "2", "3"],
+  ["4", "5", "6"],
+  ["7", "8", "9"],
+];
+
+export function NumpadModal({ visible, mode, initialValue, label, onConfirm, onClose }: Props) {
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (visible) setValue(initialValue);
+  }, [visible, initialValue]);
+
+  function handleKey(key: NumpadKey) {
+    setValue((prev) => processNumpadInput(prev, key, mode));
+  }
+
+  function handleConfirm() {
+    if (value === "") return;
+    onConfirm(value);
+  }
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose} />
+      <View style={styles.sheet}>
+        <View style={styles.header}>
+          <Text style={styles.label}>{label}</Text>
+          <Pressable onPress={onClose} hitSlop={8} testID="numpad-close">
+            <Text style={styles.closeText}>✕</Text>
+          </Pressable>
+        </View>
+
+        <Text style={styles.display} testID="numpad-display">
+          {formatNumpadDisplay(value)}
+        </Text>
+        <Text style={styles.unit}>{mode === "weight" ? "lbs" : "reps"}</Text>
+
+        <View style={styles.grid}>
+          {DIGIT_KEYS.map((row, ri) => (
+            <View key={ri} style={styles.row}>
+              {row.map((key) => (
+                <Pressable
+                  key={key}
+                  style={styles.key}
+                  onPress={() => handleKey(key)}
+                  testID={`numpad-key-${key}`}
+                >
+                  <Text style={styles.keyText}>{key}</Text>
+                </Pressable>
+              ))}
+            </View>
+          ))}
+          <View style={styles.row}>
+            {mode === "weight" ? (
+              <Pressable style={styles.key} onPress={() => handleKey(".")} testID="numpad-key-dot">
+                <Text style={styles.keyText}>.</Text>
+              </Pressable>
+            ) : (
+              <View style={styles.key} />
+            )}
+            <Pressable style={styles.key} onPress={() => handleKey("0")} testID="numpad-key-0">
+              <Text style={styles.keyText}>0</Text>
+            </Pressable>
+            <Pressable
+              style={styles.key}
+              onPress={() => handleKey("backspace")}
+              testID="numpad-backspace"
+            >
+              <Text style={styles.keyText}>⌫</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <Pressable style={styles.confirmBtn} onPress={handleConfirm}>
+          <Text style={styles.confirmText}>Confirm</Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  sheet: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: Colors.surface1,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingTop: 16,
+    paddingHorizontal: 20,
+    paddingBottom: 34,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  label: {
+    fontFamily: "DMSans_500Medium",
+    fontSize: 14,
+    color: Colors.text2,
+  },
+  closeText: {
+    color: Colors.text3,
+    fontSize: 18,
+    fontFamily: "DMSans_500Medium",
+  },
+  display: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 56,
+    color: Colors.text1,
+    textAlign: "center",
+    marginVertical: 4,
+  },
+  unit: {
+    fontFamily: "DMSans_400Regular",
+    fontSize: 14,
+    color: Colors.text3,
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  grid: {
+    gap: 8,
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  key: {
+    flex: 1,
+    minHeight: TAP_MIN,
+    backgroundColor: Colors.surface3,
+    borderRadius: RADIUS_CARD,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  keyText: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 22,
+    color: Colors.text1,
+  },
+  confirmBtn: {
+    backgroundColor: Colors.accent,
+    borderRadius: RADIUS_CARD,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  confirmText: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 20,
+    color: Colors.bg,
+  },
+});

--- a/apps/native/components/rest-timer.tsx
+++ b/apps/native/components/rest-timer.tsx
@@ -1,0 +1,87 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { Colors, RADIUS_CARD, TAP_MIN } from "@/theme";
+
+type Props = {
+  isActive: boolean;
+  remaining: number;
+  totalSeconds?: number;
+  onDismiss: () => void;
+};
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function RestTimerBanner({ isActive, remaining, totalSeconds = 90, onDismiss }: Props) {
+  if (!isActive) return null;
+
+  const progress = 1 - remaining / totalSeconds;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text style={styles.label}>REST</Text>
+        <Text style={styles.countdown} testID="rest-timer-countdown">
+          {formatCountdown(remaining)}
+        </Text>
+        <View style={{ flex: 1 }} />
+        <Pressable onPress={onDismiss} hitSlop={8} testID="rest-timer-dismiss">
+          <Text style={styles.dismissText}>✕</Text>
+        </Pressable>
+      </View>
+      <View style={styles.progressTrack} testID="rest-timer-progress">
+        <View style={[styles.progressFill, { width: `${progress * 100}%` }]} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface2,
+    borderRadius: RADIUS_CARD,
+    marginHorizontal: 16,
+    marginBottom: 8,
+    padding: 12,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 8,
+  },
+  label: {
+    fontFamily: "DMSans_600SemiBold",
+    fontSize: 12,
+    color: Colors.accent,
+    letterSpacing: 1.5,
+  },
+  countdown: {
+    fontFamily: "BebasNeue_400Regular",
+    fontSize: 22,
+    color: Colors.accent,
+  },
+  dismissText: {
+    color: Colors.text3,
+    fontSize: 16,
+    fontFamily: "DMSans_500Medium",
+    minWidth: TAP_MIN,
+    minHeight: TAP_MIN,
+    textAlign: "center",
+    lineHeight: TAP_MIN,
+  },
+  progressTrack: {
+    height: 4,
+    backgroundColor: Colors.surface4,
+    borderRadius: 2,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: 4,
+    backgroundColor: Colors.accent,
+    borderRadius: 2,
+  },
+});

--- a/apps/native/hooks/__tests__/use-elapsed-timer.test.ts
+++ b/apps/native/hooks/__tests__/use-elapsed-timer.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, act } from "@testing-library/react-native";
+
+import { useElapsedTimer, formatTime } from "../use-elapsed-timer";
+
+describe("formatTime", () => {
+  it("formats 0 seconds", () => {
+    expect(formatTime(0)).toBe("00:00");
+  });
+
+  it("formats seconds only", () => {
+    expect(formatTime(45)).toBe("00:45");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatTime(125)).toBe("02:05");
+  });
+
+  it("formats large values", () => {
+    expect(formatTime(3661)).toBe("61:01");
+  });
+});
+
+describe("useElapsedTimer", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts at 0", () => {
+    const { result } = renderHook(() => useElapsedTimer());
+    expect(result.current.elapsed).toBe(0);
+  });
+
+  it("increments every second", () => {
+    const { result } = renderHook(() => useElapsedTimer());
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(result.current.elapsed).toBe(3);
+  });
+
+  it("cleans up interval on unmount", () => {
+    const { unmount } = renderHook(() => useElapsedTimer());
+    unmount();
+    // No error means cleanup happened
+    jest.advanceTimersByTime(5000);
+  });
+
+  it("exposes formatTime function", () => {
+    const { result } = renderHook(() => useElapsedTimer());
+    expect(result.current.formatTime(90)).toBe("01:30");
+  });
+});

--- a/apps/native/hooks/__tests__/use-log-session.test.ts
+++ b/apps/native/hooks/__tests__/use-log-session.test.ts
@@ -1,0 +1,183 @@
+import { renderHook, act } from "@testing-library/react-native";
+
+import type { Workout } from "@/contexts/workout-context";
+
+import { useLogSession } from "../use-log-session";
+
+const workout: Workout = {
+  id: 1,
+  title: "Push Day",
+  createdAt: 1000,
+  exercises: [
+    {
+      id: 10,
+      workoutId: 1,
+      name: "Bench Press",
+      order: 0,
+      sets: [
+        { id: 100, exerciseId: 10, weight: 135, targetReps: 8, order: 0 },
+        { id: 101, exerciseId: 10, weight: 135, targetReps: 8, order: 1 },
+      ],
+    },
+    {
+      id: 11,
+      workoutId: 1,
+      name: "OHP",
+      order: 1,
+      sets: [{ id: 200, exerciseId: 11, weight: 95, targetReps: 10, order: 0 }],
+    },
+  ],
+};
+
+describe("useLogSession", () => {
+  it("clones exercises from workout template", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    expect(result.current.logExercises).toHaveLength(2);
+    expect(result.current.logExercises[0].name).toBe("Bench Press");
+    expect(result.current.logExercises[0].sets).toHaveLength(2);
+    expect(result.current.logExercises[0].sets[0].weight).toBe(135);
+    expect(result.current.logExercises[0].sets[0].targetReps).toBe(8);
+    expect(result.current.logExercises[0].sets[0].actualReps).toBe(8);
+    expect(result.current.logExercises[0].sets[0].done).toBe(false);
+  });
+
+  it("does not mutate original workout", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    act(() => {
+      result.current.updateWeight(0, 0, 200);
+    });
+    expect(workout.exercises[0].sets[0].weight).toBe(135);
+  });
+
+  it("updateWeight changes set weight", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    act(() => {
+      result.current.updateWeight(0, 0, 185);
+    });
+    expect(result.current.logExercises[0].sets[0].weight).toBe(185);
+  });
+
+  it("updateReps changes set actualReps", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    act(() => {
+      result.current.updateReps(0, 0, 12);
+    });
+    expect(result.current.logExercises[0].sets[0].actualReps).toBe(12);
+  });
+
+  it("toggleDone marks set as done and returns new state", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    let done: boolean;
+    act(() => {
+      done = result.current.toggleDone(0, 0);
+    });
+    expect(done!).toBe(true);
+    expect(result.current.logExercises[0].sets[0].done).toBe(true);
+  });
+
+  it("toggleDone toggles back to undone", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    act(() => {
+      result.current.toggleDone(0, 0);
+    });
+    let done: boolean;
+    act(() => {
+      done = result.current.toggleDone(0, 0);
+    });
+    expect(done!).toBe(false);
+    expect(result.current.logExercises[0].sets[0].done).toBe(false);
+  });
+
+  it("nextUndoneSet points to first undone set", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    expect(result.current.nextUndoneSet).toEqual({
+      exIdx: 0,
+      setIdx: 0,
+      exerciseName: "Bench Press",
+      setNumber: 1,
+      weight: 135,
+    });
+  });
+
+  it("nextUndoneSet advances after toggling done", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    act(() => {
+      result.current.toggleDone(0, 0);
+    });
+    expect(result.current.nextUndoneSet?.exIdx).toBe(0);
+    expect(result.current.nextUndoneSet?.setIdx).toBe(1);
+  });
+
+  it("nextUndoneSet is null when all done", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    act(() => {
+      result.current.toggleDone(0, 0);
+      result.current.toggleDone(0, 1);
+      result.current.toggleDone(1, 0);
+    });
+    expect(result.current.nextUndoneSet).toBeNull();
+  });
+
+  it("progress tracks done/total", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    expect(result.current.progress).toEqual({ done: 0, total: 3 });
+    act(() => {
+      result.current.toggleDone(0, 0);
+    });
+    expect(result.current.progress).toEqual({ done: 1, total: 3 });
+  });
+
+  it("allDone is true when all sets done", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    expect(result.current.allDone).toBe(false);
+    act(() => {
+      result.current.toggleDone(0, 0);
+      result.current.toggleDone(0, 1);
+      result.current.toggleDone(1, 0);
+    });
+    expect(result.current.allDone).toBe(true);
+  });
+
+  it("buildSession creates a valid Session object", () => {
+    const { result } = renderHook(() => useLogSession(workout));
+    act(() => {
+      result.current.updateWeight(0, 0, 140);
+      result.current.updateReps(0, 0, 6);
+      result.current.toggleDone(0, 0);
+    });
+    const startedAt = 5000;
+    let session: ReturnType<typeof result.current.buildSession>;
+    act(() => {
+      session = result.current.buildSession(startedAt);
+    });
+    expect(session!.workoutId).toBe(1);
+    expect(session!.workoutTitle).toBe("Push Day");
+    expect(session!.startedAt).toBe(5000);
+    expect(session!.finishedAt).toBeGreaterThan(0);
+    expect(session!.durationSeconds).toBeGreaterThanOrEqual(0);
+    expect(session!.exercises).toHaveLength(2);
+    expect(session!.exercises[0].sets[0].weight).toBe(140);
+    expect(session!.exercises[0].sets[0].actualReps).toBe(6);
+    expect(session!.exercises[0].sets[0].done).toBe(true);
+  });
+
+  it("handles null weight and reps in template", () => {
+    const nullWorkout: Workout = {
+      id: 2,
+      title: "Test",
+      createdAt: 1000,
+      exercises: [
+        {
+          id: 10,
+          workoutId: 2,
+          name: "Exercise",
+          order: 0,
+          sets: [{ id: 100, exerciseId: 10, weight: null, targetReps: null, order: 0 }],
+        },
+      ],
+    };
+    const { result } = renderHook(() => useLogSession(nullWorkout));
+    expect(result.current.logExercises[0].sets[0].weight).toBeNull();
+    expect(result.current.logExercises[0].sets[0].actualReps).toBeNull();
+  });
+});

--- a/apps/native/hooks/__tests__/use-rest-timer.test.ts
+++ b/apps/native/hooks/__tests__/use-rest-timer.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, act } from "@testing-library/react-native";
+
+import { useRestTimer } from "../use-rest-timer";
+
+describe("useRestTimer", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts inactive", () => {
+    const { result } = renderHook(() => useRestTimer());
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.remaining).toBe(0);
+  });
+
+  it("start begins countdown from 90", () => {
+    const { result } = renderHook(() => useRestTimer());
+    act(() => {
+      result.current.start();
+    });
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.remaining).toBe(90);
+  });
+
+  it("counts down every second", () => {
+    const { result } = renderHook(() => useRestTimer());
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(result.current.remaining).toBe(87);
+  });
+
+  it("cancel stops the timer", () => {
+    const { result } = renderHook(() => useRestTimer());
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    act(() => {
+      result.current.cancel();
+    });
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.remaining).toBe(0);
+  });
+
+  it("auto-completes at 0 and calls onComplete", () => {
+    const onComplete = jest.fn();
+    const { result } = renderHook(() => useRestTimer(onComplete));
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      jest.advanceTimersByTime(90_000);
+    });
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.remaining).toBe(0);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismiss stops the timer without calling onComplete", () => {
+    const onComplete = jest.fn();
+    const { result } = renderHook(() => useRestTimer(onComplete));
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.isActive).toBe(false);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("cleans up on unmount", () => {
+    const { result, unmount } = renderHook(() => useRestTimer());
+    act(() => {
+      result.current.start();
+    });
+    unmount();
+    jest.advanceTimersByTime(5000);
+    // No error means cleanup happened
+  });
+});

--- a/apps/native/hooks/use-elapsed-timer.ts
+++ b/apps/native/hooks/use-elapsed-timer.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState } from "react";
+
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+export function useElapsedTimer() {
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      setElapsed((prev) => prev + 1);
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  return { elapsed, formatTime };
+}

--- a/apps/native/hooks/use-log-session.ts
+++ b/apps/native/hooks/use-log-session.ts
@@ -1,0 +1,166 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import type { LoggedExercise, LoggedSet, Session, Workout } from "@/contexts/workout-context";
+
+type LogSet = {
+  weight: number | null;
+  targetReps: number | null;
+  actualReps: number | null;
+  done: boolean;
+};
+
+type LogExercise = {
+  name: string;
+  exerciseId: number;
+  sets: LogSet[];
+};
+
+export type NextUndoneSet = {
+  exIdx: number;
+  setIdx: number;
+  exerciseName: string;
+  setNumber: number;
+  weight: number | null;
+};
+
+function cloneExercises(workout: Workout): LogExercise[] {
+  return workout.exercises.map((ex) => ({
+    name: ex.name,
+    exerciseId: ex.id,
+    sets: ex.sets.map((s) => ({
+      weight: s.weight,
+      targetReps: s.targetReps,
+      actualReps: s.targetReps,
+      done: false,
+    })),
+  }));
+}
+
+export function useLogSession(workout: Workout) {
+  const [logExercises, setLogExercises] = useState<LogExercise[]>(() => cloneExercises(workout));
+  const doneRef = useRef(false);
+
+  const updateWeight = useCallback((exIdx: number, setIdx: number, value: number | null) => {
+    setLogExercises((prev) =>
+      prev.map((ex, ei) =>
+        ei === exIdx
+          ? { ...ex, sets: ex.sets.map((s, si) => (si === setIdx ? { ...s, weight: value } : s)) }
+          : ex,
+      ),
+    );
+  }, []);
+
+  const updateReps = useCallback((exIdx: number, setIdx: number, value: number | null) => {
+    setLogExercises((prev) =>
+      prev.map((ex, ei) =>
+        ei === exIdx
+          ? {
+              ...ex,
+              sets: ex.sets.map((s, si) => (si === setIdx ? { ...s, actualReps: value } : s)),
+            }
+          : ex,
+      ),
+    );
+  }, []);
+
+  const toggleDone = useCallback((exIdx: number, setIdx: number): boolean => {
+    let newDone = false;
+    setLogExercises((prev) =>
+      prev.map((ex, ei) =>
+        ei === exIdx
+          ? {
+              ...ex,
+              sets: ex.sets.map((s, si) => {
+                if (si === setIdx) {
+                  newDone = !s.done;
+                  return { ...s, done: newDone };
+                }
+                return s;
+              }),
+            }
+          : ex,
+      ),
+    );
+    doneRef.current = newDone;
+    return newDone;
+  }, []);
+
+  const nextUndoneSet = useMemo((): NextUndoneSet | null => {
+    for (let ei = 0; ei < logExercises.length; ei++) {
+      const ex = logExercises[ei];
+      for (let si = 0; si < ex.sets.length; si++) {
+        if (!ex.sets[si].done) {
+          return {
+            exIdx: ei,
+            setIdx: si,
+            exerciseName: ex.name,
+            setNumber: si + 1,
+            weight: ex.sets[si].weight,
+          };
+        }
+      }
+    }
+    return null;
+  }, [logExercises]);
+
+  const progress = useMemo(() => {
+    let done = 0;
+    let total = 0;
+    for (const ex of logExercises) {
+      for (const s of ex.sets) {
+        total++;
+        if (s.done) done++;
+      }
+    }
+    return { done, total };
+  }, [logExercises]);
+
+  const allDone = progress.done === progress.total && progress.total > 0;
+
+  const buildSession = useCallback(
+    (startedAt: number): Session => {
+      const now = Date.now();
+      const baseId = now;
+      const exercises: LoggedExercise[] = logExercises.map((ex, ei) => ({
+        id: baseId + ei + 1,
+        sessionId: baseId,
+        exerciseId: ex.exerciseId,
+        name: ex.name,
+        order: ei,
+        sets: ex.sets.map(
+          (s, si): LoggedSet => ({
+            id: baseId + ei * 100 + si + 1000,
+            loggedExerciseId: baseId + ei + 1,
+            weight: s.weight,
+            targetReps: s.targetReps,
+            actualReps: s.actualReps,
+            done: s.done,
+            order: si,
+          }),
+        ),
+      }));
+
+      return {
+        id: baseId,
+        workoutId: workout.id,
+        workoutTitle: workout.title,
+        startedAt,
+        finishedAt: now,
+        durationSeconds: Math.round((now - startedAt) / 1000),
+        exercises,
+      };
+    },
+    [logExercises, workout.id, workout.title],
+  );
+
+  return {
+    logExercises,
+    updateWeight,
+    updateReps,
+    toggleDone,
+    nextUndoneSet,
+    progress,
+    allDone,
+    buildSession,
+  };
+}

--- a/apps/native/hooks/use-rest-timer.ts
+++ b/apps/native/hooks/use-rest-timer.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const REST_SECONDS = 90;
+
+export function useRestTimer(onComplete?: () => void) {
+  const [isActive, setIsActive] = useState(false);
+  const [remaining, setRemaining] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
+  const clearTimer = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = undefined;
+    }
+  }, []);
+
+  const start = useCallback(() => {
+    clearTimer();
+    setIsActive(true);
+    setRemaining(REST_SECONDS);
+
+    intervalRef.current = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clearTimer();
+          setIsActive(false);
+          onCompleteRef.current?.();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, [clearTimer]);
+
+  const cancel = useCallback(() => {
+    clearTimer();
+    setIsActive(false);
+    setRemaining(0);
+  }, [clearTimer]);
+
+  const dismiss = useCallback(() => {
+    clearTimer();
+    setIsActive(false);
+    setRemaining(0);
+  }, [clearTimer]);
+
+  useEffect(() => {
+    return clearTimer;
+  }, [clearTimer]);
+
+  return { isActive, remaining, start, cancel, dismiss };
+}

--- a/apps/native/utils/__tests__/numpad.test.ts
+++ b/apps/native/utils/__tests__/numpad.test.ts
@@ -1,0 +1,76 @@
+import { processNumpadInput, formatNumpadDisplay } from "../numpad";
+
+describe("processNumpadInput", () => {
+  describe("digit input", () => {
+    it("appends digit to empty string", () => {
+      expect(processNumpadInput("", "5", "weight")).toBe("5");
+    });
+
+    it("appends digit to existing value", () => {
+      expect(processNumpadInput("12", "3", "weight")).toBe("123");
+    });
+
+    it("replaces leading zero with non-zero digit", () => {
+      expect(processNumpadInput("0", "5", "weight")).toBe("5");
+    });
+
+    it("allows 0 after decimal point", () => {
+      expect(processNumpadInput("1.", "0", "weight")).toBe("1.0");
+    });
+
+    it("enforces max 6 chars", () => {
+      expect(processNumpadInput("123456", "7", "weight")).toBe("123456");
+    });
+
+    it("counts decimal point in max length", () => {
+      expect(processNumpadInput("12.45", "6", "weight")).toBe("12.456");
+      expect(processNumpadInput("12.456", "7", "weight")).toBe("12.456");
+    });
+  });
+
+  describe("decimal input", () => {
+    it("adds decimal in weight mode", () => {
+      expect(processNumpadInput("12", ".", "weight")).toBe("12.");
+    });
+
+    it("prevents duplicate decimal", () => {
+      expect(processNumpadInput("12.5", ".", "weight")).toBe("12.5");
+    });
+
+    it("ignores decimal in reps mode", () => {
+      expect(processNumpadInput("12", ".", "reps")).toBe("12");
+    });
+
+    it("adds leading zero before decimal if empty", () => {
+      expect(processNumpadInput("", ".", "weight")).toBe("0.");
+    });
+  });
+
+  describe("backspace", () => {
+    it("removes last character", () => {
+      expect(processNumpadInput("123", "backspace", "weight")).toBe("12");
+    });
+
+    it("returns empty from single char", () => {
+      expect(processNumpadInput("5", "backspace", "weight")).toBe("");
+    });
+
+    it("no-op on empty string", () => {
+      expect(processNumpadInput("", "backspace", "weight")).toBe("");
+    });
+  });
+});
+
+describe("formatNumpadDisplay", () => {
+  it("returns dash for empty string", () => {
+    expect(formatNumpadDisplay("")).toBe("—");
+  });
+
+  it("returns value as-is for non-empty", () => {
+    expect(formatNumpadDisplay("135")).toBe("135");
+  });
+
+  it("returns value with decimal", () => {
+    expect(formatNumpadDisplay("12.5")).toBe("12.5");
+  });
+});

--- a/apps/native/utils/numpad.ts
+++ b/apps/native/utils/numpad.ts
@@ -1,0 +1,38 @@
+const MAX_LENGTH = 6;
+
+export type NumpadMode = "weight" | "reps";
+export type NumpadKey =
+  | "0"
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9"
+  | "."
+  | "backspace";
+
+export function processNumpadInput(current: string, key: NumpadKey, mode: NumpadMode): string {
+  if (key === "backspace") {
+    return current.slice(0, -1);
+  }
+
+  if (key === ".") {
+    if (mode === "reps") return current;
+    if (current.includes(".")) return current;
+    if (current === "") return "0.";
+    return current + ".";
+  }
+
+  // Digit
+  if (current.length >= MAX_LENGTH) return current;
+  if (current === "0") return key;
+  return current + key;
+}
+
+export function formatNumpadDisplay(value: string): string {
+  return value === "" ? "\u2014" : value;
+}


### PR DESCRIPTION
## Summary
- **Numpad modal** (#12): Custom numpad component with weight/reps modes, decimal toggle, backspace, and max-length enforcement
- **Log session screen** (#13): Full-screen session with workout header (pulsing dot, elapsed timer, progress badge), set list with tappable weight/reps cells, and numpad integration
- **Rest timer banner** (#14): 90s countdown with progress bar, auto-dismiss, haptic feedback on completion, and start/cancel tied to check toggles
- **Bottom bar** (#15): Up Next card showing next undone set with Log Reps shortcut, and Finish button that saves session to history and navigates back

## Test plan
- [x] `pnpm test:native` — 98 tests passing across 11 test suites
- [x] `pnpm check` — 0 lint errors (3 pre-existing warnings unrelated to this PR)
- [ ] Manual: tap Start on a workout, verify numpad opens on weight/reps cells
- [ ] Manual: mark sets done, verify rest timer appears and haptic fires on completion
- [ ] Manual: verify Up Next advances through sets, finish saves session

Closes #12, closes #13, closes #14, closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)