### PR TITLE
Configure backend for Cloudflare Workers deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
       BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
       BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
       CORS_ORIGIN: ${{ secrets.CORS_ORIGIN }}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -21,13 +21,12 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
-  // uncomment cookieCache setting when ready to deploy to Cloudflare using *.workers.dev domains
-  // session: {
-  //   cookieCache: {
-  //     enabled: true,
-  //     maxAge: 60,
-  //   },
-  // },
+  session: {
+    cookieCache: {
+      enabled: true,
+      maxAge: 60,
+    },
+  },
   secret: env.BETTER_AUTH_SECRET,
   baseURL: env.BETTER_AUTH_URL,
   advanced: {

--- a/packages/infra/alchemy.run.ts
+++ b/packages/infra/alchemy.run.ts
@@ -12,7 +12,7 @@ const db = await D1Database("database", {
   migrationsDir: "../../packages/db/src/migrations",
 });
 
-export const server = await Worker("server", {
+export const server = await Worker("ironmog-server", {
   cwd: "../../apps/server",
   entrypoint: "src/index.ts",
   compatibility: "node",


### PR DESCRIPTION
## Summary
- Rename Worker to `ironmog-server` for a unique `*.workers.dev` subdomain
- Enable `session.cookieCache` in Better Auth to avoid re-validating sessions on every D1 request
- Add `ALCHEMY_PASSWORD` secret to CI/CD deploy workflow so Alchemy can manage infra state

## Manual steps required
Before merging, set these GitHub repo secrets (Settings → Secrets → Actions):

| Secret | Value |
|--------|-------|
| `CLOUDFLARE_API_TOKEN` | CF API token with Workers/D1/KV permissions |
| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare Account ID |
| `ALCHEMY_PASSWORD` | `openssl rand -base64 32` |
| `BETTER_AUTH_SECRET` | `openssl rand -base64 32` |
| `BETTER_AUTH_URL` | `https://ironmog-server.<subdomain>.workers.dev` |
| `CORS_ORIGIN` | `ironlog://` |

## Test plan
- [ ] Set all 6 GitHub repo secrets
- [ ] Merge to main — CI runs check, type-check, test, then deploy
- [ ] `curl https://ironmog-server.<subdomain>.workers.dev` returns `OK`
- [ ] D1 database visible in Cloudflare Dashboard

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)